### PR TITLE
[Nago] - createElement 리팩토링 및 render, createDom 함수 구현

### DIFF
--- a/src/core/createElement/createElement.constants.ts
+++ b/src/core/createElement/createElement.constants.ts
@@ -1,0 +1,2 @@
+export const TEXT_ELEMENT = 'TEXT_ELEMENT' as const;
+export const EMPTY_CHILDREN: [] = [];

--- a/src/core/createElement/createElement.ts
+++ b/src/core/createElement/createElement.ts
@@ -7,25 +7,26 @@ function createTextElement(text: string): TextVNode {
 			nodeValue: text,
 			children: [],
 		},
+		key: null,
 	};
 }
 
-export function createElement({
-	type,
-	props,
-	children,
-}: {
-	type: string;
-	props?: Record<string, unknown>;
-	children: (VNode | string)[];
-}): VNode {
+export function createElement(
+	type: string,
+	props: {
+		[key: string]: unknown;
+		children: (VNode | string)[];
+	},
+	key: string | null = null,
+): VNode {
 	return {
 		type,
 		props: {
-			...(props || {}),
-			children: children.map((child) =>
+			...props,
+			children: props.children.map((child) =>
 				typeof child === 'object' ? child : createTextElement(child),
 			),
 		},
+		key,
 	};
 }

--- a/src/core/createElement/createElement.ts
+++ b/src/core/createElement/createElement.ts
@@ -1,11 +1,12 @@
+import { EMPTY_CHILDREN, TEXT_ELEMENT } from './createElement.constants';
 import type { TextVNode, VNode } from './createElement.types';
 
 function createTextElement(text: string): TextVNode {
 	return {
-		type: 'TEXT_ELEMENT',
+		type: TEXT_ELEMENT,
 		props: {
 			nodeValue: text,
-			children: [],
+			children: EMPTY_CHILDREN,
 		},
 		key: null,
 	};

--- a/src/core/createElement/createElement.types.ts
+++ b/src/core/createElement/createElement.types.ts
@@ -4,6 +4,7 @@ export type VNode = {
 		[key: string]: unknown;
 		children: VNode[];
 	};
+	key: string | null;
 };
 
 export type TextVNode = {
@@ -12,4 +13,5 @@ export type TextVNode = {
 		nodeValue: string;
 		children: [];
 	};
+	key: null;
 };

--- a/src/core/createElement/index.ts
+++ b/src/core/createElement/index.ts
@@ -1,2 +1,3 @@
 export * from './createElement';
 export * from './createElement.types';
+export * from './createElement.constants';

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,0 +1,1 @@
+export * from './createElement';

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,1 +1,2 @@
 export * from './createElement';
+export * from './render';

--- a/src/core/render/index.ts
+++ b/src/core/render/index.ts
@@ -1,0 +1,1 @@
+export * from './render';

--- a/src/core/render/render.ts
+++ b/src/core/render/render.ts
@@ -1,0 +1,27 @@
+import type { VNode } from '@core/createElement';
+
+export function createDom(vNode: VNode): Node {
+	const { type, props } = vNode;
+
+	const dom: Node =
+		type === 'TEXT_ELEMENT'
+			? document.createTextNode(props.nodeValue as string)
+			: document.createElement(type);
+
+	for (const [key, value] of Object.entries(props)) {
+		if (key !== 'children') {
+			// biome-ignore lint/suspicious/noExplicitAny: 문자열 키(key)를 통해 동적으로 DOM 프로퍼티에 값을 할당하기 위해 명시적 any 캐스트가 필요합니다.
+			(dom as any)[key] = value;
+		}
+	}
+
+	for (const child of props.children) dom.appendChild(createDom(child));
+
+	return dom;
+}
+
+export function render(vnode: VNode, container: Element) {
+	container.innerHTML = '';
+
+	container.appendChild(createDom(vnode));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,1 @@
+export * from './core';

--- a/tests/helpers/sampleElements.ts
+++ b/tests/helpers/sampleElements.ts
@@ -10,4 +10,5 @@ export const SAMPLE_TEXT_ELEMENT = {
 		nodeValue: TEXT_NODE_VALUE,
 		children: EMPTY_CHILDREN,
 	},
+	key: null,
 };

--- a/tests/unit/createElement.test.ts
+++ b/tests/unit/createElement.test.ts
@@ -1,54 +1,35 @@
 import { createElement } from '@core/createElement';
-import { TEXT_ELEMENT_TYPE, TEXT_NODE_VALUE } from '@helpers/constants';
+import { TEXT_NODE_VALUE } from '@helpers/constants';
 import { SAMPLE_TEXT_ELEMENT } from '@helpers/sampleElements';
 import { describe, expect, it } from 'vitest';
 
 describe('createElement', () => {
-	it('올바른 타입과 props로 요소를 생성해야 한다', () => {
-		const element = createElement({
-			type: 'div',
-			props: { id: 'app' },
-			children: ['Hello', 'World'],
-		});
-
-		expect(element.type).toBe('div');
-		expect(element.props.id).toBe('app');
-		expect(element.props.children).toHaveLength(2);
-
-		// 첫 번째 자식은 텍스트 노드로 변환되어야 함
-		expect(element.props.children[0]).toEqual({
-			type: TEXT_ELEMENT_TYPE,
-			props: {
-				nodeValue: 'Hello',
-				children: [],
-			},
-		});
+	it('기본 key(null)와 props(children) 없이 생성하면 빈 children 배열을 가진다', () => {
+		const el = createElement('div', { children: [] });
+		expect(el.type).toBe('div');
+		expect(el.key).toBeNull();
+		expect(el.props.children).toEqual([]);
 	});
 
-	it('자식 요소를 올바르게 중첩해서 생성해야 한다', () => {
-		const childElement = createElement({
-			type: 'span',
-			props: {},
-			children: ['Nested'],
-		});
-
-		const parentElement = createElement({
-			type: 'div',
-			props: {},
-			children: [childElement],
-		});
-
-		expect(parentElement.props.children).toHaveLength(1);
-		expect(parentElement.props.children[0]).toBe(childElement);
+	it('세 번째 인자로 전달한 key를 그대로 설정한다', () => {
+		const el = createElement('section', { children: [] }, 'custom-key');
+		expect(el.key).toBe('custom-key');
 	});
 
-	it('createTextElement 결과와 동일한 텍스트 노드를 생성해야 한다', () => {
-		const element = createElement({
-			type: 'span',
-			props: {},
-			children: [TEXT_NODE_VALUE],
-		});
+	it('문자열 자식을 TEXT_ELEMENT로 변환하고, nodeValue/children을 올바르게 설정한다', () => {
+		const el = createElement('p', { children: [TEXT_NODE_VALUE] });
+		expect(el.props.children).toHaveLength(1);
+		expect(el.props.children[0]).toEqual(SAMPLE_TEXT_ELEMENT);
+	});
 
-		expect(element.props.children[0]).toEqual(SAMPLE_TEXT_ELEMENT);
+	it('VNode 자식을 레퍼런스 그대로 유지한다', () => {
+		const child = createElement(
+			'span',
+			{ children: [TEXT_NODE_VALUE] },
+			'child-key',
+		);
+		const parent = createElement('div', { children: [child] }, 'parent-key');
+		expect(parent.props.children).toHaveLength(1);
+		expect(parent.props.children[0]).toBe(child);
 	});
 });


### PR DESCRIPTION
## `createElement` 리팩토링 이유
- 학습하던 중 `Classic Runtime`과 `Automatic Runtime` 두 가지 JSX 변환 방식이 이 있다는 것을 알게 됨
- 기존에 구현한 `creatElement`의 시그니처는 아래와 같았음
```typescript
function createElement(type, props, children) {~}
```
- 하지만 React 17+ 도입된 `Automatic Runtime` 방식에서는 `children`을 별도 인자로 받지 않고  `props.children`에 포함시키며 `key`를 세 번째 인자로 받음
- 따라서  `Automatic Runtime`의 호출 형태에 맞추어 함수 시그니처를 아래와 같이 변경
```typescript
function createElement(type, props, key = null) {~}
```
- 리액트 최신버전에 맞게 구현하는 것이 더 올바른 방향이라 판단하여 이와 같이 리팩토링함
- 좀 더 자세한 설명 =>> [런타임 방식 비교 by gpt](https://github.com/Nago730/fe-my-react/wiki/%EB%9F%B0%ED%83%80%EC%9E%84-%EB%B0%A9%EC%8B%9D-%EB%B9%84%EA%B5%90(classic,-Automatic))
---
## `render`, `createDom` 함수 구현
- `render`: 가상 노드를 실제 DOM으로 삽입
- `createDom` DOM 노드 생성 로직을 분리한 함수
- 일단 최대한 간단하게 구현해봤음
---
## 향후 개발 방향 및 고민
- createElement 구현 => 테스트 코드 작성 완료
- render 구현까지 완료했음. 이제 테스트 코드를 작성할 예정인데, 직접 타이핑 하기에는 시간이 꽤나 소요되기 때문에 AI를 적극 활용하여 테스트 코드를 작성하고자 함.
- createElement와 render에 대한 유닛 테스트를 진행한 후, 통합 테스트를 진행해야 하는지?
  - 두 함수는 매우 밀접하기 때문에 통합 테스트를 진행할 가치가 있다고 생각함
  - 하지만 이 타이밍에 통합 테스트를 하는 게 꼭 필요한지는 잘 모르겠음