### PR TITLE
[wanja] 이벤트 위임 기능 추가

### DIFF
--- a/src/__tests__/eventDelegation.test.js
+++ b/src/__tests__/eventDelegation.test.js
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { initEventDelegation } from '../core/event';
+
+describe('event delegation', () => {
+  let root;
+
+  beforeEach(() => {
+    root = document.createElement('div');
+    document.body.appendChild(root);
+    initEventDelegation(root);
+  });
+
+  test('click 이벤트가 위임되어 핸들러가 실행된다', () => {
+    const button = document.createElement('button');
+    const handleClick = vi.fn();
+
+    button.__vnode = { props: { onClick: handleClick } };
+    root.appendChild(button);
+
+    button.click();
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('핸들러가 없는 경우 실행되지 않는다', () => {
+    const div = document.createElement('div');
+    div.__vnode = { props: {} };
+    root.appendChild(div);
+
+    div.click();
+
+    expect(true).toBe(true); // 에러 없이 통과
+  });
+
+  test('부모에 핸들러가 있으면 위임되어 실행된다', () => {
+    const parent = document.createElement('div');
+    const child = document.createElement('button');
+    const handleClick = vi.fn();
+
+    parent.__vnode = { props: { onClick: handleClick } };
+    parent.appendChild(child);
+    root.appendChild(parent);
+
+    child.click();
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('root에서 직접 이벤트가 발생하면 무시된다', () => {
+    const handleClick = vi.fn();
+    root.__vnode = { props: { onClick: handleClick } };
+
+    root.click();
+
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
+  test('focusin 이벤트를 통해 onFocus 핸들러가 우회 실행된다', () => {
+    const input = document.createElement('input');
+    const handleFocus = vi.fn();
+
+    input.__vnode = { props: { onFocus: handleFocus } };
+    root.appendChild(input);
+
+    const focusinEvent = new FocusEvent('focusin', { bubbles: true });
+    input.dispatchEvent(focusinEvent);
+
+    expect(handleFocus).toHaveBeenCalledTimes(1);
+  });
+
+  test('focusout 이벤트를 통해 onBlur 핸들러가 우회 실행된다', () => {
+    const input = document.createElement('input');
+    const handleBlur = vi.fn();
+
+    input.__vnode = { props: { onBlur: handleBlur } };
+    root.appendChild(input);
+
+    const focusoutEvent = new FocusEvent('focusout', { bubbles: true });
+    input.dispatchEvent(focusoutEvent);
+
+    expect(handleBlur).toHaveBeenCalledTimes(1);
+  });
+
+  test('mouseover 이벤트를 통해 onMouseEnter 핸들러가 실행된다', () => {
+    const div = document.createElement('div');
+    const handleEnter = vi.fn();
+
+    div.__vnode = { props: { onMouseEnter: handleEnter } };
+    root.appendChild(div);
+
+    const mouseoverEvent = new MouseEvent('mouseover', { bubbles: true });
+    div.dispatchEvent(mouseoverEvent);
+
+    expect(handleEnter).toHaveBeenCalledTimes(1);
+  });
+
+  test('mouseout 이벤트를 통해 onMouseLeave 핸들러가 실행된다', () => {
+    const div = document.createElement('div');
+    const handleLeave = vi.fn();
+
+    div.__vnode = { props: { onMouseLeave: handleLeave } };
+    root.appendChild(div);
+
+    const mouseoutEvent = new MouseEvent('mouseout', { bubbles: true });
+    div.dispatchEvent(mouseoutEvent);
+
+    expect(handleLeave).toHaveBeenCalledTimes(1);
+  });
+
+  test('stopPropagation 호출 시 상위 핸들러 실행되지 않음', () => {
+    const parent = document.createElement('div');
+    const child = document.createElement('button');
+
+    const parentHandler = vi.fn();
+    const childHandler = (e) => {
+      e.stopPropagation();
+    };
+
+    parent.__vnode = { props: { onClick: parentHandler } };
+    child.__vnode = { props: { onClick: childHandler } };
+
+    parent.appendChild(child);
+    root.appendChild(parent);
+
+    child.click();
+
+    expect(parentHandler).not.toHaveBeenCalled();
+  });
+
+  test('stopPropagation 호출하지 않으면 상위 핸들러까지 실행됨', () => {
+    const parent = document.createElement('div');
+    const child = document.createElement('button');
+
+    const parentHandler = vi.fn();
+    const childHandler = vi.fn();
+
+    parent.__vnode = { props: { onClick: parentHandler } };
+    child.__vnode = { props: { onClick: childHandler } };
+
+    parent.appendChild(child);
+    root.appendChild(parent);
+
+    child.click();
+
+    expect(childHandler).toHaveBeenCalled();
+    expect(parentHandler).toHaveBeenCalled();
+  });
+});

--- a/src/app/main.jsx
+++ b/src/app/main.jsx
@@ -2,4 +2,5 @@ import { render } from '../core/render';
 import App from './App';
 
 const root = document.getElementById('root');
+
 render(<App name="wanja" />, root);

--- a/src/core/event.js
+++ b/src/core/event.js
@@ -1,0 +1,69 @@
+export const eventMap = Object.freeze({
+  click: 'onClick',
+  dblclick: 'onDoubleClick',
+  mousedown: 'onMouseDown',
+  mouseup: 'onMouseUp',
+  mouseover: 'onMouseEnter',
+  mouseout: 'onMouseLeave',
+  keydown: 'onKeyDown',
+  keyup: 'onKeyUp',
+  input: 'onInput',
+  change: 'onChange',
+  submit: 'onSubmit',
+  focusin: 'onFocus',
+  focusout: 'onBlur',
+  contextmenu: 'onContextMenu',
+  pointerdown: 'onPointerDown',
+  pointerup: 'onPointerUp',
+  dragstart: 'onDragStart',
+  dragend: 'onDragEnd'
+});
+
+export function initEventDelegation(root) {
+  // 같은 root에 중복 위임 방지
+  if (root.__delegated) return;
+
+  Object.keys(eventMap).forEach((eventType) => {
+    root.addEventListener(eventType, (event) => {
+      handleDelegatedEvent(event, root);
+    });
+  });
+
+  root.__delegated = true;
+}
+
+function handleDelegatedEvent(event, root) {
+  const eventType = event.type;
+  const propKey = eventMap[eventType];
+  if (!propKey) return;
+
+  const syntheticEvent = createSyntheticEvent(event);
+
+  let node = event.target;
+
+  while (node && node !== root) {
+    const vnode = node.__vnode;
+    const handler = vnode?.props?.[propKey];
+    if (typeof handler === 'function') {
+      handler(syntheticEvent);
+    }
+
+    if (syntheticEvent.__stopped) break;
+
+    node = node.parentNode;
+  }
+}
+
+function createSyntheticEvent(nativeEvent) {
+  nativeEvent.__stopped = false;
+
+  const originalStop = nativeEvent.stopPropagation;
+  nativeEvent.stopPropagation = function () {
+    nativeEvent.__stopped = true;
+    if (typeof originalStop === 'function') {
+      originalStop.call(nativeEvent);
+    }
+  };
+
+  return nativeEvent;
+}

--- a/src/core/render.js
+++ b/src/core/render.js
@@ -1,3 +1,6 @@
+import { isEventHandler } from './utils/dom';
+import { initEventDelegation } from './event';
+
 /**
  * Virtual DOM(VNode)을 실제 DOM으로 변환하여 container에 마운트합니다.
  * React의 렌더링 방식과 유사하게 동작하며, 함수형 컴포넌트도 처리합니다.
@@ -29,6 +32,9 @@ export function render(vnode, container) {
 
   const dom = createDom(vnode);
   container.appendChild(dom);
+
+  //이벤트 위임
+  initEventDelegation(container);
 }
 
 /**
@@ -60,10 +66,16 @@ function createDom(vnode) {
 
   // prop 설정 (className, 기타 속성 처리)
   for (const key in props) {
+    const value = props[key];
+
+    if (isEventHandler(key)) {
+      continue; // 이벤트 핸들러는 DOM 속성에 추가하지 않음
+    }
+
     if (key === 'className') {
-      dom.className = props[key];
-    } else if (key !== 'children' && key !== 'key') {
-      dom.setAttribute(key, props[key]);
+      dom.className = value;
+    } else if (key !== 'children') {
+      dom.setAttribute(key, value);
     }
   }
 
@@ -71,6 +83,9 @@ function createDom(vnode) {
   const children = Array.isArray(props.children)
     ? props.children
     : [props.children];
+
+  //_vnode 속성 추가
+  dom.__vnode = vnode;
 
   //재귀적으로 자식 랜더링
   children.filter(isRenderable).forEach((child) => {

--- a/src/core/utils/dom.js
+++ b/src/core/utils/dom.js
@@ -1,0 +1,15 @@
+import { eventMap } from '../event';
+/**
+ * 주어진 키가 유효한 DOM 이벤트 핸들러 이름인지 확인합니다.
+ *
+ * JSX에서 onClick, onInput 등으로 들어온 키를 검사하여
+ * 실제 DOM 이벤트로 바인딩 가능한지 여부를 반환합니다.
+ *
+ * @param {string} key - 검사할 props 키 값 (예: 'onClick')
+ * @returns {boolean} - 유효한 이벤트 핸들러 키이면 true, 아니면 false
+ */
+export function isEventHandler(key) {
+  if (!key.startsWith('on')) return false;
+
+  return Object.values(eventMap).includes(key);
+}


### PR DESCRIPTION
## 주요 작업 목록

- `eventMap`을 통해 DOM 이벤트와 `props` 속성(`onClick`, `onInput` 등)을 매핑하고, 이를 기반으로 위임 처리
- `initEventDelegation(root)`에서 root 노드에 모든 이벤트 타입을 한 번씩만 위임 등록 (중복 방지 `__delegated` 플래그 포함)
- `handleDelegatedEvent()`는 `event.target`부터 시작해 상위 노드로 올라가며 해당 vnode에 연결된 이벤트 핸들러를 찾아 실행
- `createSyntheticEvent()`를 통해 `nativeEvent.stopPropagation()`을 감싸 `__stopped` 플래그를 설정하여 버블링 제어 가능
- focus/blur/mouseenter/mouseleave 같은 비버블링 이벤트는 `focusin`/`focusout`/`mouseover`/`mouseout` 등 버블링 이벤트로 위임 처리

## 주요 고민과 해결

#### 1. 이벤트 시스템의 구조를 어떻게 설계할 것인가?

❓ 고민  
- React처럼 하나의 루트에 이벤트를 위임하는 구조를 어떻게 구현할 수 있을지 고민함  
- React의 실제 동작 구조(`dispatchEvent`, `EventPluginHub`, `ReactDOMEventListener`)를 소스코드로 분석해, 이벤트가 어떤 흐름으로 처리되는지 파악함  
- 사용자 정의 핸들러를 어떻게 찾아야 하는지, 그리고 `props.onClick` 같은 이름을 어떻게 매핑할지도 함께 고민

✅ 해결  
- `eventMap`을 만들어 DOM 이벤트명과 `props` 속성명을 매핑  
- 루트 노드에만 이벤트를 위임하도록 하고, `event.target`부터 상위 노드를 순회하며 `__vnode.props[onClick]` 형태로 핸들러를 찾아 실행  
- React처럼 이벤트 위임은 루트에 단 한 번만 일어나도록 설계함

---

#### 2. vnode와 DOM 노드 간의 연결을 어떻게 유지할 것인가?

❓ 고민  
- 이벤트 발생 시 `event.target`만으로는 연결된 가상 노드를 알 수 없음  
- React는 Fiber 구조를 통해 이를 추적하지만, 우리는 바닐라 JS 기반이라 별도 연결이 필요함

✅ 해결  
- DOM 노드에 `__vnode` 속성으로 연결된 vnode를 직접 부착  
- 이로써 이벤트가 발생한 노드에서 직접 props와 핸들러를 추적 가능  
- 이 방식은 React의 Fiber 구조에서 `stateNode`와 연결하는 방식과 유사함

---

#### 3. stopPropagation을 어떻게 감지하고 구현할 것인가?

❓ 고민  
- JS 기본 `stopPropagation()`은 브라우저의 내부 버블링을 멈추지만, 우리가 직접 돌리는 while 루프에서는 전혀 영향을 주지 않음  
- 사용자가 `e.stopPropagation()`을 호출했을 때 상위 노드로의 전파를 멈추고 싶었음

✅ 해결  
- `nativeEvent.stopPropagation()`을 래핑하여 내부에 `__stopped = true`를 설정하도록 구현  
- 루프에서 이 플래그를 감지해 위임된 버블링 흐름을 수동으로 멈출 수 있도록 처리  
- 완전히 커스텀한 synthetic 이벤트 흐름을 구성한 셈

---

#### 4. 버블링이 안되는 이벤트는 어떻게 위임할 수 있을까?

❓ 고민  
- `focus`, `blur`, `mouseenter`, `mouseleave` 등은 원래 위임이 불가능한 비버블링 이벤트임  
- 하지만 리액트는 이들도 위임하고 있음 → 어떻게 가능하지?

✅ 해결  
- React처럼 버블링 가능한 대체 이벤트로 대체:  
  - `focus` → `focusin`  
  - `blur` → `focusout`  
  - `mouseenter` → `mouseover`  
  - `mouseleave` → `mouseout`  
- `eventMap` 자체를 대체 이벤트 기반으로 구성하여 위임이 가능한 구조로 전환

---

#### 5. 이벤트 중복 등록을 어떻게 방지할 것인가?

❓ 고민  
- `render()`가 여러 번 호출되거나, 여러 이벤트가 있는 노드일 때 `addEventListener()`가 중복 호출될 수 있음  
- 성능 저하 및 메모리 누수를 유발할 수 있는 문제

✅ 해결  
- 루트 노드에 `__delegated`라는 커스텀 플래그를 설정하여 중복 위임 방지  
- 이미 위임이 설정된 경우 `initEventDelegation()`은 바로 종료되도록 설계

---

#### 6. render 함수가 이벤트 위임까지 책임져야 할까?

❓ 고민  
- `render()`는 본래 "VNode를 실제 DOM으로 그리는 것"에만 집중해야 하는데, 여기에 이벤트 위임까지 포함시키는 건 **역할이 너무 많아지는 것 아닌가?** 하는 의문이 있었음  
- 특히, **렌더링이 반복 호출될 경우 매번 `initEventDelegation(root)`이 실행되는 것은 불필요한 낭비**로 보였고, 이를 방지하고 싶었음  
- 그래서 `createRoot(container)` 같은 초기화 전용 API를 만들고, **이벤트 위임은 그 안에서 한 번만 설정하고**, 실제 `render()`는 오직 렌더링만 책임지게 하자는 구조도 한때 고려했었음

✅ 해결  
- 최종적으로는 **단일 진입점을 유지하고 구현을 단순화하기 위해**, `render()` 내부에서 `initEventDelegation()`을 호출하는 현재 구조를 유지하기로 결정  
- 대신 `container.__delegated` 플래그를 도입하여, **이벤트 위임은 단 한 번만 설정되도록** 방어 로직을 추가함  
- 이를 통해 함수 분리 없이도 중복 위임 문제를 해결하고, API를 단순하게 유지할 수 있었음  
- 향후 프레임워크를 더 확장하게 된다면, `createRoot()` 같은 구조로 분리할 수 있도록 여지는 남겨둔 상태

---

## 고민되는 점....

하지만 최적화라 추후로 미루는 것이 좋을지 지금 파는 게 좋을지 고민이네요...

모든 이벤트를 미리 root에 등록하는 것은 불필요한 작업이 될 수 있다. 이를 최적화 할 방법이 있을까?
-> vnode를 돌면서 핸들러 함수를 발견하면 그 이벤트 타입을 Set같은 데이터에 보관하고, 이벤트 위임 함수에서 해당 set을 반복문을 돌려서 이벤트 등록을 하면 어떨까...? 라는 아이디어만 있고 미뤄놨습니다.... 이때 첫 render이후 동적으로 이벤트가 생성되면 그땐 또 어떻게...?
-> 이 모든 작업을 처리하는 함수보다 초반에 이벤트 등록을 전부 하는 게 더 나을 거 같기도 하고....?

이벤트위임 중복 방지를 위한 flag속성을 node의 속성이 아니라 다르게 관리하면 어떨까?
-> 메모리로 들고 있다던가......

테스트 코드 어떻게 뭘 더 테스트 해야하지....? 단순한 테스트만 하는 기분입니다? 
