### PR TITLE
[Milo] - 개발 환경 구성, 이벤트 위임 방식 리팩토링, rendering  퍼포먼스 측정

### DIFF
--- a/jsx-demo/app.jsx
+++ b/jsx-demo/app.jsx
@@ -3,6 +3,17 @@ function App() {
     <div>
       <h1>JSX Demo</h1>
       <p>이것은 JSX 데모입니다.</p>
+      <button onClick={() => console.log("클릭 이벤트 발생!")}>
+        이건 버튼입니다.
+      </button>
+      <button onClick={() => console.log("버블링 감지 성공입니다!")}>
+        <span>버블링 감지 버튼입니다.</span>
+        <div>
+          <div>버블링 div1</div>
+          <div>버블링 div2</div>
+          <div>버블링 div3</div>
+        </div>
+      </button>
     </div>
   );
 }

--- a/jsx-demo/app.jsx
+++ b/jsx-demo/app.jsx
@@ -1,3 +1,5 @@
+import { performanceInstrument } from "./performance/performanceInstrument";
+
 function App() {
   return (
     <div>
@@ -53,3 +55,4 @@ function App() {
 // DOM에 렌더링
 const root = document.getElementById("root");
 MyReact.render(<App />, root);
+performanceInstrument(root, <App />);

--- a/jsx-demo/app.jsx
+++ b/jsx-demo/app.jsx
@@ -1,19 +1,51 @@
 function App() {
   return (
     <div>
-      <h1>JSX Demo</h1>
-      <p>이것은 JSX 데모입니다.</p>
-      <button onClick={() => console.log("클릭 이벤트 발생!")}>
-        이건 버튼입니다.
+      <h1>JSX Performance Test</h1>
+
+      {/* 입력 상태 유지 테스트용 인풋 */}
+      <div>
+        <label htmlFor="textInput">텍스트 입력:</label>
+        <input
+          id="textInput"
+          type="text"
+          placeholder="여기에 입력하세요"
+          defaultValue="초기값"
+        />
+      </div>
+
+      {/* 클릭 핸들러 테스트용 버튼 */}
+      <button id="logButton" onClick={() => console.log("로그 버튼 클릭!")}>
+        로그 버튼
       </button>
-      <button onClick={() => console.log("버블링 감지 성공입니다!")}>
-        <span>버블링 감지 버튼입니다.</span>
-        <div>
-          <div>버블링 div1</div>
-          <div>버블링 div2</div>
-          <div>버블링 div3</div>
-        </div>
-      </button>
+
+      {/* 대량 리스트 렌더링 테스트 */}
+      <ul>
+        {Array.from({ length: 100 }, (_, i) => (
+          <li key={i} onClick={() => console.log(`리스트 아이템 ${i} 클릭`)}>
+            리스트 아이템 {i}
+          </li>
+        ))}
+      </ul>
+
+      {/* 중첩 섹션 및 이벤트 버블링 테스트 */}
+      {["A", "B", "C"].map((section) => (
+        <section key={section}>
+          <h2>섹션 {section}</h2>
+          <div>
+            {[1, 2, 3].map((item) => (
+              <div
+                key={item}
+                onClick={() =>
+                  console.log(`섹션 ${section} - 아이템 ${item} 클릭`)
+                }
+              >
+                섹션 {section} - 아이템 {item}
+              </div>
+            ))}
+          </div>
+        </section>
+      ))}
     </div>
   );
 }

--- a/jsx-demo/performance/performanceInstrument.js
+++ b/jsx-demo/performance/performanceInstrument.js
@@ -1,0 +1,24 @@
+import MyReact from "@/core";
+
+export function performanceInstrument(root, Component) {
+  // 3) 퍼포먼스 측정용 이름 지정
+  const MEASURE = ["첫 렌더링", "두 번째 렌더링"];
+  performance.clearMarks();
+  performance.clearMeasures();
+
+  for (let a = 1; a < 3; a++) {
+    root.innerHTML = "";
+    performance.mark(`start${a}`);
+    MyReact.render(Component, root);
+    performance.mark(`end${a}`);
+    performance.measure(MEASURE[a - 1], `start${a}`, `end${a}`);
+  }
+
+  // 결과 출력
+  console.table(
+    performance.getEntriesByType("measure").map(({ name, duration }) => ({
+      name,
+      duration: duration.toFixed(6) + "ms",
+    }))
+  );
+}

--- a/jsx-demo/performance/performanceInstrument.js
+++ b/jsx-demo/performance/performanceInstrument.js
@@ -1,24 +1,31 @@
 import MyReact from "@/core";
 
 export function performanceInstrument(root, Component) {
-  // 3) 퍼포먼스 측정용 이름 지정
   const MEASURE = ["첫 렌더링", "두 번째 렌더링"];
+
+  // 실제 측정: N번 반복
+  const N = 50;
   performance.clearMarks();
   performance.clearMeasures();
-
-  for (let a = 1; a < 3; a++) {
+  for (let a = 1; a < N; a++) {
+    //App에서 실행한 워밍업용 렌더링 초기화
     root.innerHTML = "";
     performance.mark(`start${a}`);
     MyReact.render(Component, root);
     performance.mark(`end${a}`);
-    performance.measure(MEASURE[a - 1], `start${a}`, `end${a}`);
+    performance.measure(`run${a}`, `start${a}`, `end${a}`);
   }
+
+  const measures = performance.getEntriesByType("measure");
 
   // 결과 출력
   console.table(
-    performance.getEntriesByType("measure").map(({ name, duration }) => ({
+    measures.map(({ name, duration }) => ({
       name,
       duration: duration.toFixed(6) + "ms",
     }))
   );
+  //평균값 계싼
+  const total = measures.reduce((sum, m) => sum + m.duration, 0);
+  console.log("Average render time:", (total / N).toFixed(3), "ms");
 }

--- a/src/core/render/attachHandlers.ts
+++ b/src/core/render/attachHandlers.ts
@@ -22,6 +22,6 @@ export function attachHandlers(
   handler: (e: Event) => void
 ) {
   registerEvent(action);
-  el[HANDLERS] = el[HANDLERS] ?? {};
-  el[HANDLERS][action] = handler;
+  el[HANDLERS] = el[HANDLERS] ? el[HANDLERS] : {};
+  el[HANDLERS]![action] = handler;
 }

--- a/src/core/render/attachHandlers.ts
+++ b/src/core/render/attachHandlers.ts
@@ -1,4 +1,5 @@
 import { HANDLERS } from "./render";
+import { registerEvent } from "./eventHandelr";
 
 // 2) 전역 HTMLElement 인터페이스 확장
 declare global {
@@ -20,6 +21,7 @@ export function attachHandlers(
   action: string,
   handler: (e: Event) => void
 ) {
+  registerEvent(action);
   el[HANDLERS] = el[HANDLERS] ?? {};
   el[HANDLERS][action] = handler;
 }

--- a/src/core/render/eventHandelr.ts
+++ b/src/core/render/eventHandelr.ts
@@ -1,0 +1,10 @@
+// 이벤트 등록 전용 맵
+export const eventList = new Set();
+
+/**
+ *
+ * @param action 각 노드에 발생하는 이벤트를 입력하여 등록합니다.
+ */
+export function registerEvent(action: string): void {
+  eventList.add(action);
+}

--- a/src/core/render/eventHandelr.ts
+++ b/src/core/render/eventHandelr.ts
@@ -1,5 +1,5 @@
 // 이벤트 등록 전용 맵
-export const eventList = new Set();
+export const eventList: Set<string> = new Set();
 
 /**
  *

--- a/src/core/render/internalRender.ts
+++ b/src/core/render/internalRender.ts
@@ -28,8 +28,8 @@ export function internalRender(vnode: VNode, parent: Node): void {
       prop !== "children" &&
       typeof value === "function"
     ) {
-      const eventHandler = mapPropToAttr(prop);
-      attachHandlers(rootNode, eventHandler, value);
+      const eventName = mapPropToAttr(prop);
+      attachHandlers(rootNode, eventName, value);
     }
     //표준 HTML 속성
     else if (value != null && value !== false) {

--- a/src/core/render/render.ts
+++ b/src/core/render/render.ts
@@ -1,7 +1,7 @@
 import type { VNode } from "@/shared/types/vnode";
 import { internalRender } from "./internalRender";
 // (1) 이벤트 위임 초기화 상태 플래그
-let isEventDelegationInitialized = false;
+const delegatedContainers = new WeakSet<Node>();
 
 // (2) 심벌 키 생성
 export const HANDLERS = Symbol("__handlers"); //Symbol.for
@@ -9,7 +9,7 @@ export const HANDLERS = Symbol("__handlers"); //Symbol.for
 export function render(vnode: VNode, container: Node): void {
   //---------------------------------------------------------
   // (3) 한 번만: 최상위 컨테이너에 click 위임 리스너 등록
-  if (!isEventDelegationInitialized) {
+  if (!delegatedContainers.has(container)) {
     container.addEventListener("click", (event: Event) => {
       let origin = event.target as HTMLElement | null;
       //이벤트 핸들러가 바인딩된 노드까지 위로 올라가야한다. -> .parent
@@ -22,7 +22,7 @@ export function render(vnode: VNode, container: Node): void {
         origin = origin.parentElement;
       }
     });
-    isEventDelegationInitialized = true;
+    delegatedContainers.add(container);
   }
   //---------------------------------------------------------
 

--- a/src/core/render/render.ts
+++ b/src/core/render/render.ts
@@ -1,5 +1,7 @@
 import type { VNode } from "@/shared/types/vnode";
 import { internalRender } from "./internalRender";
+import { eventList } from "./eventHandelr";
+
 // (1) 이벤트 위임 초기화 상태 플래그
 const delegatedContainers = new WeakSet<Node>();
 
@@ -7,30 +9,35 @@ const delegatedContainers = new WeakSet<Node>();
 export const HANDLERS = Symbol("__handlers"); //Symbol.for
 
 export function render(vnode: VNode, container: Node): void {
-  //---------------------------------------------------------
-  // (3) 한 번만: 최상위 컨테이너에 click 위임 리스너 등록
-  if (!delegatedContainers.has(container)) {
-    container.addEventListener("click", (event: Event) => {
-      let origin = event.target as HTMLElement | null;
-      //이벤트 핸들러가 바인딩된 노드까지 위로 올라가야한다. -> .parent
-      while (!!origin && origin !== container) {
-        const handler = (origin as HTMLElement)[HANDLERS]?.click;
-        if (typeof handler === "function") {
-          handler.call(origin, event);
-          return;
-        }
-        origin = origin.parentElement;
-      }
-    });
-    delegatedContainers.add(container);
-  }
-  //---------------------------------------------------------
-
   // 2) 빌드 단계: DocumentFragment 생성
   const fragment: DocumentFragment = document.createDocumentFragment();
 
   // 3) internalRender로 전체 트리를 fragment에 구축
   internalRender(vnode, fragment);
+
+  //---------------------------------------------------------
+  // (3) 한 번만: 최상위 컨테이너에 click 위임 리스너 등록
+  if (!delegatedContainers.has(container)) {
+    eventList.forEach((eventAction: string) => {
+      container.addEventListener(eventAction, (event: Event) => {
+        let origin = event.target as HTMLElement | null;
+        //이벤트 핸들러가 바인딩된 노드까지 위로 올라가야한다. -> .parent
+        while (!!origin && origin !== container) {
+          const handler = (origin as HTMLElement)[HANDLERS]
+            ? (origin as HTMLElement)[HANDLERS]![eventAction]
+            : null;
+          if (typeof handler === "function") {
+            handler.call(origin, event);
+            return;
+          }
+          origin = origin.parentElement;
+        }
+      });
+    });
+
+    delegatedContainers.add(container);
+  }
+  //---------------------------------------------------------
 
   // 4) 커밋 단계: fragment를 실제 container에 한 번에 붙임
   container.appendChild(fragment);


### PR DESCRIPTION
# MyReact 프레임워크 작업 내역 & 고민 기록

2025-06-14 부터 지금까지 `/core`(프레임워크 코드)와 `/jsx-demo`(테스트·데모 코드)를 분리하고, Classic JSX 런타임을 적용하며 겪었던 주요 작업 내용과 그 과정에서의 고민들을 정리합니다.

---

## 📅 작업 개요

1. **개발 환경 구성**  
2. **Render 함수 리팩토링**  
3. **Render 퍼포먼스 측정 함수 구현**

---

## 🛠️ 1. 개발 환경 구성

- **커밋**  
  - `✨ Myreact 생성` (`1c865b5`)  
  - `✨ 개발환경 구성완료` (`3670be4`)  
  - `🐛 환경 설정 최종 수정 완료` (`0369120`)  
  - `🐛 별칭 적용 범위 수정` (`124a2f4`)  
  - `✨ vitest 환경 설정 완료` (`7dcb30b`)  
  - `✨ 프레임 워크 테스트 코드 구현` (`284510a`)

- **고민 & 해결**  
  - **TSConfig 별칭 미인식**  
    - *고민*: `@core/*`만 동작하고 `@core` bare import는 안 됨  
    - *대화 중 물음*: “왜 VSCode에선 인식하는데 vite dev 서버에선 별칭이 안 잡힐까?”  
    - *해결*: `tsconfig.json`에 `"@core": ["core/index.ts"]` 추가, `vite-tsconfig-paths({ projects: [...] })`로 최상위 tsconfig 명시  
  - **404 & FS-ALLOW 에러**  
    - *고민*: “왜 `root: jsx-demo`로 지정했는데도 `/app.jsx`가 404가 날까?”  
    - *설명 중 배운 점*: `root`와 `server.fs.allow`는 역할이 다르고, `fs.allow`에 `jsx-demo`를 추가해야 파일 시스템에서 읽어준다  
    - *해결*: `server.fs.allow = [path.resolve(__dirname, "src"), path.resolve(__dirname, "jsx-demo")]`  
  - **ESBuild include 패턴 문제**  
    - *고민*: “`.jsx` 파일이 변환 대상에서 빠져 있는 것 같은데 include 옵션을 어디에 써야 하지?”  
    - *해결*: `esbuild.include: [/\.jsx$/]` 설정 추가  

-  <a href="https://velog.io/@y-minion/MyReact-%ED%94%84%EB%A0%88%EC%9E%84%EC%9B%8C%ED%81%AC-core%EC%99%80-jsx-demo-%ED%99%98%EA%B2%BD-%EB%B6%84%EB%A6%AC-%EB%B0%8F-Classic-JSX-%EB%9F%B0%ED%83%80%EC%9E%84-%EC%A0%81%EC%9A%A9%EA%B8%B0">📚 관련 위키</a>
---

## 🔄 2. Render 함수 리팩토링

- **커밋**  
  - `♻️ 이벤트 위임 방식 리펙토링` (`4d1f9d4`)  
  - `✨ eventHandler 파일 구현 완료` (`e4772f8`)  
  - `♻️ WeakSet이용해 안정성 증가` (`27ac656`)  
  - `🐛 이벤트 등록 순서 변경` (`33648fe`)  
  - `♻️ 타입지정` (`3b83332`, `69b456d`)  
  - `♻️ internalRender함수의 변수명 수정` (`c0c38dc`)

### 고민 & 해결

#### 이벤트 위임 vs 개별 바인딩  
- **고민**  
  - 모든 이벤트마다 `addEventListener`를 호출하는 것은 비효율적이다.  
  - 반면, 상위 컨테이너에 단 한 번만 위임 핸들러를 등록하려면 어떻게 해야 할까?  
- **해결**  
  1. **최상위 컨테이너에 위임 핸들러 등록**  
     - `render` 함수가 호출될 때마다 이벤트 리스너가 중복 등록되지 않도록, `WeakSet` (`delegatedContainers`)에 등록 여부를 기록한다.  
     - `delegatedContainers.has(container)`가 `false`일 때만 실제로 `container.addEventListener(...)`를 실행하여 “한 번만” 위임 핸들러를 등록한다.  
  2. **`WeakSet`을 사용한 이유**  
     - 단순 `boolean` 플래그로 등록 여부를 관리하면, `render` 함수가 여러 번 호출될 때 최초 실행 시점에만 등록되고 이후에는 의도한 대로 동작하지 않는 문제가 있었다.  
     - `WeakSet`은 컨테이너 노드를 그 자체(key)로 저장하므로, 각 컨테이너마다 정확히 한 번만 이벤트 위임이 일어난다.

#### 필요한 이벤트만 위임하기  
- **고민**  
  - 어떤 이벤트 종류가 실제로 사용될지 알 수 없는데, 모든 가능 이벤트를 일괄 등록하면 불필요한 리스너가 많아져 성능 저하 우려가 있다.  
- **해결**  
  1. **전역 `Set`에 사용 이벤트 수집**  
     - `attachHandlers(el, action, handler)` 호출 시 내부에서 `registerEvent(action)`을 통해 전역 `eventList: Set<string>`에 `action`을 추가한다.  
     - 이 과정은 가상 노드를 순회하면서 **props** 중 이벤트 핸들러가 있는 경우마다 실행된다.  
  2. **렌더링 순서 변경**  
     - 가상 노드 트리를 완전히 순회(`internalRender`)해 `eventList`에 “실제로 필요한” 이벤트 목록을 모두 채운 뒤에,  
     - 그제야 최상위 컨테이너에 `eventList`를 순환하며 **필요한 이벤트만** `addEventListener`로 위임 등록한다.  
  3. **효과**  
     - 불필요한 이벤트 리스너 등록을 방지하여 메모리·성능 부담을 최소화  
     - 실제 사용되는 이벤트만 한 번에 모아서 위임 처리하므로, 런타임 오버헤드 감소  
-> 이렇게 함으로써, **최소한의 이벤트 리스너**로 **효율적인 이벤트 위임**을 구현할 수 있었음.  
---

## 📈 3. Render 퍼포먼스 측정 함수 구현

- **커밋**  
  - `♻️ 성능 테스트용 코드 수정` (`029c306`)  
  - `✨ 퍼포먼스 측정 코드` (`0707158`)  
  - `♻️ 퍼포먼스 측정 함수 수정` (`be9f6fa`)

- **고민 & 해결**  
  - **측정 시점과 반복 횟수**  
    - *고민*: “단일 렌더 호출 시간 vs 여러 번 반복 후 평균, 어느 쪽이 의미 있을까?”  
    - *결정*: 50회 반복 후 평균값 계산   
