### PR TITLE
[Nago] - Fiber 삭제 후 Naber 도입 및 useState 구현 중

### DIFF
--- a/src/core/applyRef.ts
+++ b/src/core/applyRef.ts
@@ -1,9 +1,0 @@
-import type { MutableRefObject, Ref } from '../types/base.types';
-
-export function applyRef(dom: Node, ref: Ref | undefined) {
-	if (typeof ref === 'function') {
-		ref(dom);
-	} else if (ref && typeof ref === 'object' && 'current' in ref) {
-		(ref as MutableRefObject<Node>).current = dom;
-	}
-}

--- a/src/core/domEffects.ts
+++ b/src/core/domEffects.ts
@@ -1,0 +1,16 @@
+import type { MutableRefObject, Ref, VNodeProps } from '../types/base.types';
+
+export function applyRef(dom: Node, ref: Ref | undefined) {
+	if (typeof ref === 'function') {
+		ref(dom);
+	} else if (ref && typeof ref === 'object' && 'current' in ref) {
+		(ref as MutableRefObject<Node>).current = dom;
+	}
+}
+
+export function applyProps(dom: Node, props: VNodeProps) {
+	for (const [key, value] of Object.entries(props)) {
+		if (key === 'children') continue;
+		(dom as any)[key] = value;
+	}
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,3 +1,3 @@
 export * from './render';
 export * from './constants';
-export * from './applyRef';
+export * from './domEffects';

--- a/src/core/render.ts
+++ b/src/core/render.ts
@@ -1,32 +1,22 @@
-import { buildFiberTree } from '../runtime/fiber';
+import { getNaberTree } from '../runtime/naber';
 import type {
-	Fiber,
 	FragmentVNode,
+	Naber,
 	TextVNode,
 	VNode,
 } from '../types/base.types';
-import { applyRef } from './applyRef';
 import { FRAGMENT, TEXT_ELEMENT } from './constants';
+import { applyProps, applyRef } from './domEffects';
 
-function createRootFiber(vnode: VNode): Fiber {
-	const rootFiber: Fiber = {
-		type: vnode.type,
-		props: vnode.props,
-		parent: null,
-		child: null,
-		sibling: null,
-		memoizedState: [],
-		hookIndex: 0,
-	};
+export function createDom(naber: Naber, fragment: Node): void {
+	// Naber가 FunctionComponent 일 때, 자식을 재귀
+	if (typeof naber.type === 'function') {
+		for (const child of naber.children) createDom(child, fragment);
+		return;
+	}
 
-	if (vnode.key) rootFiber.key = vnode.key;
-	if (vnode.ref) rootFiber.ref = vnode.ref;
-
-	return rootFiber;
-}
-
-export function createDom(fiber: Fiber): Node | null {
-	const { type, props, ref } = fiber;
+	// Naber가 HostElement 일 때
+	const { type, props, children, ref } = naber;
 
 	let dom: Node;
 
@@ -35,51 +25,28 @@ export function createDom(fiber: Fiber): Node | null {
 	else if (typeof type === 'string') {
 		dom = document.createElement(type);
 
-		for (const [key, value] of Object.entries(props)) {
-			if (key === 'children') continue;
-			(dom as any)[key] = value;
-		}
+		if (props) applyProps(dom, props);
+		if (ref) applyRef(dom, ref);
 	} else {
-		// 예상되지 않는 상황이므로 무시
-		return null;
+		// type이 예상하지 못한 값일 때, appenChild를 하지 않기 위해 return함
+		return;
 	}
 
-	if (ref) applyRef(dom, ref);
+	if (children) for (const child of children) createDom(child, dom);
 
-	return dom;
-}
-
-function commitToVirtualContainer(
-	fiber: Fiber,
-	container: DocumentFragment | Element,
-) {
-	const dom = createDom(fiber);
-	if (dom) container.appendChild(dom);
-
-	if (fiber.child && dom)
-		commitToVirtualContainer(fiber.child, dom as DocumentFragment | Element);
-	if (fiber.sibling) commitToVirtualContainer(fiber.sibling, container);
+	fragment.appendChild(dom);
 }
 
 export function render(
 	vnode: VNode | TextVNode | FragmentVNode,
 	container: Element,
 ): void {
-	const rootVNode =
-		typeof vnode.type === 'function'
-			? (vnode.type as Function)(vnode.props)
-			: vnode;
+	const naber = getNaberTree(vnode);
 
-	const rootFiber: Fiber = createRootFiber(rootVNode);
+	const fragment = document.createDocumentFragment();
 
-	const children = rootVNode.props.children ?? [];
-
-	buildFiberTree(rootFiber, children);
-
-	const virtualContainer = document.createDocumentFragment();
-
-	commitToVirtualContainer(rootFiber, virtualContainer);
+	createDom(naber, fragment);
 
 	container.innerHTML = '';
-	container.appendChild(virtualContainer);
+	container.appendChild(fragment);
 }

--- a/src/core/render.ts
+++ b/src/core/render.ts
@@ -41,7 +41,12 @@ export function render(
 	vnode: VNode | TextVNode | FragmentVNode,
 	container: Element,
 ): void {
-	const naber = getNaberTree(vnode);
+	const rootVNode =
+		typeof vnode.type === 'function'
+			? (vnode.type as Function)(vnode.props)
+			: vnode;
+
+	const naber = getNaberTree(rootVNode);
 
 	const fragment = document.createDocumentFragment();
 

--- a/src/runtime/naber.ts
+++ b/src/runtime/naber.ts
@@ -1,0 +1,83 @@
+import type { Naber, VNode } from '@src/types/base.types';
+
+/**
+ * 전역 naber 상태를 담는 객체입니다.
+ * - `naberRoot`: 루트 Naber 트리
+ * - `currentlyRenderingNaber`: 현재 렌더링 중인 함수형 컴포넌트 Naber
+ */
+const naber = {
+	/** 최상위 Naber 트리 객체 */
+	naberRoot: null as Naber | null,
+
+	/** 현재 렌더링 중인 함수형 컴포넌트의 Naber 객체 */
+	currentlyRenderingNaber: null as Naber | null,
+};
+
+/**
+ * 루트 Naber 객체를 반환합니다.
+ * @returns {Naber | null} 현재 저장된 루트 Naber 객체
+ */
+const getNaberRoot = (): Naber | null => naber.naberRoot;
+
+/**
+ * 현재 렌더링 중인 함수형 컴포넌트의 Naber 객체를 반환합니다.
+ * @returns {Naber | null} 현재 렌더링 중인 Naber 객체
+ */
+const getCurrentWorkingNaber = (): Naber | null =>
+	naber.currentlyRenderingNaber;
+
+/**
+ * 단일 VNode를 기반으로 Naber 객체를 생성합니다.
+ * @param {VNode} vnode - 변환 대상 VNode
+ * @returns {Naber} 생성된 Naber 객체
+ */
+const createNaber = (vnode: VNode): Naber => {
+	const { children, ...restProps } = vnode.props;
+	return {
+		type: vnode.type,
+		props: restProps,
+		children: [],
+		key: vnode.key || null,
+		ref: vnode.ref || null,
+		memoizedState: [],
+		hookIndex: 0,
+	};
+};
+
+/**
+ * Naber 트리를 재귀적으로 구축합니다.
+ * @param {Naber} parentNaber - 현재 부모 Naber 객체
+ * @param {VNode[]} vnodeChildren - 자식 VNode 목록
+ */
+const buildNaberTree = (parentNaber: Naber, vnodeChildren: VNode[]): void => {
+	for (const vnode of vnodeChildren) {
+		const naber: Naber = createNaber(vnode);
+
+		parentNaber.children.push(naber);
+
+		if (typeof naber.type === 'function') {
+			const renderedVNode = (naber.type as Function)({
+				...naber.props,
+				children: naber.children,
+			});
+			const children = renderedVNode.props.children ?? [];
+			buildNaberTree(naber, children);
+		} else {
+			const children = vnode.props.children ?? [];
+			buildNaberTree(naber, children);
+		}
+	}
+};
+
+/**
+ * 주어진 VNode를 기반으로 전체 Naber 트리를 생성합니다.
+ * @param {VNode} vnode - 루트 VNode
+ * @returns {Naber} 구축된 Naber 트리의 루트 객체
+ */
+const getNaberTree = (vnode: VNode): Naber => {
+	const naberRoot: Naber = createNaber(vnode);
+	buildNaberTree(naberRoot, vnode.props.children);
+	return naberRoot;
+};
+
+export { getNaberRoot, getCurrentWorkingNaber, getNaberTree };

--- a/src/runtime/useState.ts
+++ b/src/runtime/useState.ts
@@ -28,6 +28,26 @@ export function reRender(currentWorkingNaber: Naber) {
 	const { children: prevNaber, type: FC } = currentWorkingNaber;
 	const nextNaber: Naber[] = (FC as Function)();
 
-	// Diff는 아직 미구현
 	Diff(prevNaber, nextNaber);
+}
+
+/**
+ * 작성 중...
+ *
+ * @param prevNaber
+ * @param nextNaber
+ */
+// function Diff(prev: Naber[], next: Naber[]) {}
+
+function isSameNaber(prev: Naber, next: Naber): boolean {
+	if (prev.key !== next.key) return false;
+	if (prev.type !== next.type) return false;
+	// props shallow compare
+	for (const key in prev.props)
+		if (prev.props[key] !== next.props[key]) return false;
+
+	for (const key in next.props)
+		if (next.props[key] !== prev.props[key]) return false;
+
+	return true;
 }

--- a/src/runtime/useState.ts
+++ b/src/runtime/useState.ts
@@ -1,0 +1,33 @@
+import type { Naber } from '../types/base.types';
+import { getCurrentWorkingNaber } from './naber';
+
+export function useState<T>(initialValue: T): [T, (newValue: T) => void] {
+	const currentWorkingNaber: Naber | null = getCurrentWorkingNaber();
+	if (!currentWorkingNaber) throw new Error('현재 작업 중인 Naber가 없습니다');
+
+	// 현재 Fiber의 hookIndex에 해당하는 상태를 가져오거나 초기값으로 설정합니다.
+	const { memoizedState, hookIndex } = currentWorkingNaber;
+	const oldState = memoizedState[hookIndex];
+	const state: T = oldState === undefined ? initialValue : oldState;
+
+	// setState 함수
+	const setState = (param: T) => {
+		if (typeof param === 'function') memoizedState[hookIndex] = param(state);
+		else memoizedState[hookIndex] = param;
+
+		reRender(currentWorkingNaber);
+	};
+
+	// 다음 useState 호출을 위해 hookIndex를 증가시킵니다.
+	currentWorkingNaber.hookIndex++;
+
+	return [state, setState];
+}
+
+export function reRender(currentWorkingNaber: Naber) {
+	const { children: prevNaber, type: FC } = currentWorkingNaber;
+	const nextNaber: Naber[] = (FC as Function)();
+
+	// Diff는 아직 미구현
+	Diff(prevNaber, nextNaber);
+}

--- a/src/types/base.types.ts
+++ b/src/types/base.types.ts
@@ -48,3 +48,13 @@ export interface Fiber {
 	memoizedState: any[];
 	hookIndex: number;
 }
+
+export interface Naber {
+	type: string | Function | symbol;
+	props: VNodeProps;
+	children: Naber[];
+	key: string | null;
+	ref: Ref | null;
+	memoizedState: any[];
+	hookIndex: number;
+}


### PR DESCRIPTION
## Fiber에서 Naber까지
- 노드가 부모, 형제, 첫 번째 자식을 가지는 자료구조는 불필요하다고 판단하여 제거했습니다
- 다중 컴포넌트 상태 관리, 조건부 렌더링 등의 기능을 포함한 useState를 구현하기 위한 설계를 마쳤습니다.

## useState 구현을 위한 작업 목록
- [x] 상태 관리의 기반이 될 Naber 아키텍처 도입
- [x] Naber 구조에 맞게 render 함수 리팩토링
- [x] useState 함수 구현
- [ ] 변경된 컴포넌트만 다시 렌더링하기 위한 재조정(Reconciliation) 로직 구현
- [ ] 재조정 단계에서 활용되는 Diff 알고리즘 구현

## 내가 구현할 useState는 어떻게 동작하는가?
- 상태는 Naber 단위로 보존됨
- hookIndex를 통해 각 useState 호출의 순서를 보장함
- 조건부 렌더링 환경에서도 상태가 안정적으로 유지됨
- 상태 변경 시, currentWorkingNaber부터 리렌더가 시작되므로,
  실제 변경된 컴포넌트만 영향을 받고 나머지 하위 컴포넌트의 상태는 유지됨
### 중요하게 생각한 점
```mathematica
A
└── B
    ├── C
    ├── D
    └── E

```
- 위 구조에서 C, D, E는 각각 개별 상태를 가진 컴포넌트임
- 이때 상위 노드인 A나 B의 상태가 변경되더라도, 하위 컴포넌트의 상태가 무조건 초기화되지 않고, 실제로 변경이 발생한 컴포넌트만 다시 렌더링되도록 동작하는 걸 useState의 동작 방식으로 설정
- 위 내용을 구현하기 위해 재조정과 Diff 알고리즘이 필수적이었고, 실제로도 불필요한 상태 초기화를 방지하는 방향으로 재조정 및 Diff 설계함

### 구현하며 얻은 인사이트
- 상태 관리, 재조정, Diff 알고리즘은 상호 독립적이지 않으며, 함께 설계되어야 함
- 재조정 및 Diff가 없다면 상태 변경 시 매번 상태 초기화가 발생함
- 조건부 렌더링은 별도로 고려하지 않았지만, 재조정과 Diff를 갖추면 자연스럽게 처리됨
- 전체 트리 기반으로 작동하기 때문에 재귀 호출, 트리 탐색 로직에 대한 감각이 향상됨
- 아직 구체화하진 않았지만, useState를 구현한 기반 위에서 useEffect 등 다른 상태 관리 훅도 비교적 단순하게 구현 가능할 것으로 예상됨

