### PR TITLE
[wanja] useState 및 리랜더링 구현

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,7 +17,14 @@ export default [
     ]
   },
   {
-    files: ['**/*.test.js', '**/__tests__/**/*.js'],
+    files: [
+      '**/*.test.js',
+      '**/__tests__/**/*.js',
+      '**/*.test.jsx',
+      '**/__tests__/**/*.jsx',
+      '**/*.test.jsx',
+      '**/__tests__/**/*.jsx'
+    ],
     plugins: {
       vitest
     },

--- a/src/__tests__/useState.test.jsx
+++ b/src/__tests__/useState.test.jsx
@@ -1,0 +1,166 @@
+import { useState } from '../core/useState';
+import { render } from '../core/render';
+import { createElement } from '../core/createElement';
+
+describe('useState 훅', () => {
+  let root;
+  let vnode;
+
+  beforeEach(() => {
+    root = document.createElement('div');
+  });
+
+  afterEach(() => {
+    delete window.fire;
+    delete window.inc1;
+    delete window.inc2;
+    delete window.bump;
+  });
+
+  function mount(AppComponent) {
+    vnode = createElement(AppComponent);
+    render(vnode, root);
+  }
+
+  it('초기 상태값이 DOM에 정확히 반영되어야 한다', () => {
+    const App = () => {
+      const [count] = useState(5);
+      return <div data-testid="count">{count}</div>;
+    };
+
+    mount(App);
+    const countNode = root.querySelector('[data-testid="count"]');
+    expect(countNode.textContent).toBe('5');
+  });
+
+  it('상태 변경 시 변경된 상태 값으로 다시 렌더링되어야 한다', () => {
+    const App = () => {
+      const [count, setCount] = useState(1);
+      window.fire = () => setCount((prev) => prev + 1);
+      return <div data-testid="count">{count}</div>;
+    };
+
+    mount(App);
+    const getCount = () => root.querySelector('[data-testid="count"]');
+
+    expect(getCount().textContent).toBe('1');
+    window.fire();
+    expect(getCount().textContent).toBe('2');
+    window.fire();
+    expect(getCount().textContent).toBe('3');
+  });
+
+  it('여러 useState 호출 간 상태가 독립적으로 유지되어야 한다', () => {
+    const App = () => {
+      const [count1, setCount1] = useState(0);
+      const [count2, setCount2] = useState(100);
+      window.inc1 = () => setCount1((prev) => prev + 1);
+      window.inc2 = () => setCount2((prev) => prev + 10);
+      return (
+        <div>
+          <span data-testid="count1">{count1}</span>
+          <span data-testid="count2">{count2}</span>
+        </div>
+      );
+    };
+
+    mount(App);
+    const getCount1 = () => root.querySelector('[data-testid="count1"]');
+    const getCount2 = () => root.querySelector('[data-testid="count2"]');
+
+    expect(getCount1().textContent).toBe('0');
+    expect(getCount2().textContent).toBe('100');
+    window.inc1();
+    expect(getCount1().textContent).toBe('1');
+    expect(getCount2().textContent).toBe('100');
+    window.inc2();
+    expect(getCount1().textContent).toBe('1');
+    expect(getCount2().textContent).toBe('110');
+  });
+
+  it('상태 변경 후 vnode.__dom이 새로운 DOM 노드를 가리켜야 한다', () => {
+    const App = () => {
+      const [count, setCount] = useState(0);
+      window.bump = () => setCount((c) => c + 1);
+      return <div data-testid="count">num: {count}</div>;
+    };
+
+    mount(App);
+    const initialDom = vnode.__dom;
+    window.bump();
+    const updatedDom = vnode.__dom;
+
+    const countNode = root.querySelector('[data-testid="count"]');
+    expect(updatedDom).toBe(countNode);
+    expect(updatedDom).not.toBe(initialDom);
+    expect(updatedDom.textContent).toBe('num: 1');
+  });
+
+  it('중첩 컴포넌트에서 상태 변경 시 해당 부분만 다시 렌더링되어야 한다', () => {
+    const App = () => {
+      const [countA, setCountA] = useState(0);
+      const [countB, setCountB] = useState(0);
+      window.incA = () => setCountA((c) => c + 1);
+      window.incB = () => setCountB((c) => c + 1);
+
+      function Outer({ children }) {
+        return <section>{children}</section>;
+      }
+
+      function Inner({ label, count, onInc }) {
+        return (
+          <div data-testid={`inner-${label}`}>
+            <span>
+              {label}: {count}
+            </span>
+            <button data-testid={`btn-${label}`} onClick={onInc}>
+              Inc
+            </button>
+          </div>
+        );
+      }
+
+      return (
+        <Outer>
+          <Inner label="A" count={countA} onInc={window.incA} />
+          <Inner label="B" count={countB} onInc={window.incB} />
+        </Outer>
+      );
+    };
+
+    mount(App);
+
+    // 초기 DOM 노드 참조 저장
+    const nodeA1 = root.querySelector('[data-testid="inner-A"]');
+    const nodeB1 = root.querySelector('[data-testid="inner-B"]');
+
+    // A 컴포넌트의 상태만 변경
+    window.incA();
+
+    // 변경 후 DOM 노드 참조
+    const nodeA2 = root.querySelector('[data-testid="inner-A"]');
+    const nodeB2 = root.querySelector('[data-testid="inner-B"]');
+
+    // A는 교체
+    expect(nodeA2).not.toBe(nodeA1);
+    expect(nodeA2.textContent).toContain('A: 1');
+
+    // B는 그대로 유지
+    expect(nodeB2.textContent).toBe(nodeB1.textContent);
+    expect(nodeB2.textContent).toContain('B: 0');
+  });
+
+  it('같은 값으로 setState 호출 시 리렌더링되지 않아야 한다', () => {
+    let renderCount = 0;
+    const App = () => {
+      const [count, setCount] = useState(0);
+      window.same = () => setCount(0);
+      renderCount++;
+      return <div data-testid="count">{count}</div>;
+    };
+    mount(App);
+    expect(renderCount).toBe(1);
+    window.same();
+    expect(renderCount).toBe(1); // 값이 같으므로 리렌더링 없어야 함
+  });
+});

--- a/src/core/componentState.js
+++ b/src/core/componentState.js
@@ -1,0 +1,10 @@
+// 함수 컴포넌트 상태 맵핑 데이터 구조
+const componentMap = new WeakMap();
+
+export function getComponentState(componentFn) {
+  return componentMap.get(componentFn);
+}
+
+export function setComponentState(componentFn, state) {
+  componentMap.set(componentFn, state);
+}

--- a/src/core/context.js
+++ b/src/core/context.js
@@ -1,0 +1,9 @@
+export let __CURRENT_STATE = null;
+
+export function setCurrentState(state) {
+  __CURRENT_STATE = state;
+}
+
+export function getCurrentState() {
+  return __CURRENT_STATE;
+}

--- a/src/core/useState.js
+++ b/src/core/useState.js
@@ -1,0 +1,27 @@
+import { getCurrentState } from './context';
+
+export function useState(initialValue) {
+  //현재 설정된 컴포넌트의 상태 가져오기
+  const state = getCurrentState();
+  const { hookIndex, stateBucket } = state;
+
+  if (stateBucket[hookIndex] === undefined) {
+    stateBucket[hookIndex] = initialValue;
+  }
+
+  const currentIndex = hookIndex;
+
+  function setState(nextValue) {
+    const prev = stateBucket[currentIndex];
+    const next = typeof nextValue === 'function' ? nextValue(prev) : nextValue;
+    if (Object.is(prev, next)) {
+      return; // 값이 동일하면 리렌더링 방지
+    }
+    stateBucket[currentIndex] = next;
+    state.rerender();
+  }
+
+  state.hookIndex++;
+
+  return [stateBucket[hookIndex], setState];
+}


### PR DESCRIPTION
## 작업 완료 내역

- ✨ 기능 추가
  - `useState` 훅 구현: `WeakMap` 기반의 `componentMap`을 통해 컴포넌트별 `stateBucket` 관리 도입  
  - `setState` 호출 시 부분 리렌더링 지원을 위한 `rerender` 로직 추가

- 🐛 버그 수정
  - `setState` 내부에 `Object.is` 비교 로직을 통합하여, 동일 값 업데이트 시 불필요한 리렌더링 방지

- 🏗️ 구조 및 설계
  - `renderFunctionComponent` 내부 로직 분리  
    - `initComponentInstance`  
    - `prepareHookContext`  
    - `createRerenderCallback`  
  - 네이밍 및 모듈 구조 정리

## 주요 고민 및 해결과정

👉 useState 설계 문서 : https://github.com/wan0514/fe-my-react/wiki/%5B%EC%84%A4%EA%B3%84%5D-useState

1. **컴포넌트별 상태 저장소 설계**  
   - React처럼 각 함수형 컴포넌트마다 독립된 훅 컨텍스트가 필요하여, `WeakMap`을 사용해 GC 친화적인 `componentMap`을 도입했습니다.  
   - 훅 호출 순서를 맞추기 위해 `hookIndex`를 상태 객체에 포함시키고, 매 렌더링마다 `prepareHookContext`에서 초기화하도록 구현했습니다.

2. **부분 리렌더링 메커니즘**  
   - 전체 DOM을 교체하는 대신, 변경된 컴포넌트의 최상위 DOM만 교체하도록 `createRerenderCallback`을 통해 `vnode.__dom.replaceWith(newDom)` 방식을 채택했습니다.  
   - 이로써 1차적으로 diff 알고리즘 없이 부분 리랜더링 매커니즘을 구현했습니다.
     - ❌ 현재 이 부분 설계가 잘못되어 버그가 발생했습니다. 재설계 진행중입니다.

3. **불필요 리렌더링 방지**  
   - 테스트를 통해 동일한 값으로 업데이트할 때도 렌더링이 발생하는 문제를 발견했고, `Object.is` 비교를 통해 이를 해결했습니다.  
   - 테스트 코드(`useState` 훅 동작 검증)를 추가하여 안정성을 확보했습니다.

4. **코드 가독성 및 유지보수성 강화**  
   - `renderFunctionComponent`의 역할이 복잡해지면서 헬퍼 함수들을 분리해 책임을 명확히 했습니다.  
   - 네이밍을 `evaluateFunctionComponent*`에서 `renderFunctionComponent`로 통일해 흐름을 한눈에 파악할 수 있도록 개선했습니다.

---

## 해결 중인 문제

- **현상 요약**  
  1. 자식 `setState` 호출 → 자식만 정상 리렌더링  
  2. 부모 컴포넌트에서 `setState` 호출 → 부모 + 자식 전체 리렌더링  
  3. 이후 다시 자식 `setState` 호출 → 변경사항이 반영되지 않음  

- **디버깅 확인한 원인**  
  - 부모 리렌더링 후 생성된 자식 컴포넌트 인스턴스가, 이전 자식 인스턴스와 서로 다른 객체(reference)임을 확인  
  - 이로 인해 `rerender` 콜백이 여전히 이전 인스턴스의 `oldDom`을 참조하게 되어 교체가 실패함  

- **해결 방법 모색 중…**
  - 노드가 새로 생성되더라도 해당 노드를 구별할 수 있는 key속성을 따로 부여하면 인스턴스가 바뀌더라도 교체가 가능하지 않을까…?
  - diff를 구현하면 인스턴스 교체 문제가 해결되겠지만, diff 없이도 부분 랜더링이 동작하게 할 수 있어야 한다
  - 애초에 부분리랜더링 구현을 위한 전체 돔트리 비교는 필수불가결한 요소가 아닐까?...
  - 가상 dom 없이도 가능하지 않을까?? 모든 프레임워크가 가상 dom이 있지 않아도 상태 변경과 리랜더링이 되는 것을 생각하면 방법을 좀 더 고민해도 될 거 같다?

> 애초에 리액트의 재조정과정, diff 등에 대한 흐름 이해의 부족으로 설계가 부족했기 때문에 학습을 먼저 진행하고 재설계를 해보려 합니다.

[👉 학습중인 목록](https://github.com/users/wan0514/projects/5/views/1?pane=issue&itemId=116427027&issue=wan0514%7Cfe-my-react%7C35)
