### PR TITLE
[Milo] -상태 관리 시스템 설계 및 구현 상세 정리

### DIFF
--- a/src/core/hook/hookManager/README.md
+++ b/src/core/hook/hookManager/README.md
@@ -1,0 +1,107 @@
+# HookManager 설계
+
+- 프레임워크에서 사용되는 상태를 관리하는 매니저를 설계한다.
+
+## 개요
+
+- render 함수 실행시 VNode를 순환하면서 type이 함수일 경우에 함수를 실행 시켜 내부의 코드를 실행시키게 된다.
+- 이때 코드 내부에 hook이 등장할 경우 상태를 조작하는 로직이 있어야 한다.
+- 하지만 상태를 조작하는 로직이 정상적으로 작동을 하려면 각 VNode에 해당하는 상태를 갖고있는 공간이 있어야 하는데 현재는 UI를 그릴 수 있는 VNode만 존재하고 내부의 데이터를 담을 수 있는 공간은 준비되지 않았다.
+- 각 노드와 내부 상태를 연결해 주는 "무언가" 가 필요하다..!
+  - 처음에는 1대1 대응 관계를 생각했는데 그럴 필요가 없다. 'internalRender'함수가 실행될때 내부 상태 코드가 실행되는데 이때 상태 관련 훅도 실행되게 되는데 이때 VNode안에 새로운 훅 관련 필드와 연결을 할 계획이다.
+  - 세부 설계에서 자세하게 설명하겠다.
+- 그래서 해당 매니저의 필요성을 느끼고 설계 하게 되었다.
+
+## 설계
+
+### 흐름 파악
+
+- Render 이후에 createElement로 만들어진 VNode 트리를 순회하는 internalRender 함수에서 각 VNode를 순회하면서 type이 function일 경우에 함수를 실행시킨다.
+- 이때 '함수를 실행시킨다' 하는 말은 즉, 해당 함수 내부의 코드들이 실행된다는 말이고, 내부에 상태를 조작하는 훅이 있으면 작성한 코드에 맞게 로직이 실행된다는 의미다.
+- 그러면 internalRender 함수가 실행되는 타이밍에 상태를 관리해주는 로직(사용자가 사용할 수 있는 hook)이 있어야한다.
+- 그래서 해당 HookManager가 등장하는 위치는 internalRender 함수로 결정 했다.
+- 사실 처음에는 바로 useState 훅 부터 만드려고 했지만 전체적으로 hook들이 갖고 있는 공통적인 프로세스가 있어서 공통된 작업은 함수로 분리해서 관리를 하려고 했고 결국 생각한게 이 hookManger이다.
+
+### 세부 설계
+
+- 이때 앞서 말했듯이 internalRender 함수 내부에서 각 VNode를 순환한다고 했는데 이 말은 즉, internalRender함수에서 type 이 function인 순간에 해당하는 VNode에 접근할 수 있다는 말이 된다.
+
+- 그래서 각각의 순환되는 VNode와 단위로 실행되는 함수 내부에 HookMetaData = {hooks:[],hooksPointer=0} 와 같은 필드를 먼저 생성한다. 해당 데이터는 HookManger 내부에서 사용된다.
+
+- 입력: 매개변수를 입력 받지 않는다.
+
+  - 하지만 해당 함수는 처음에 internal함수에서 해당하는 VNode객체를 사용할 수 있어야 한다.
+  - 입력 없이 어떻게 사용하지...?
+  - VNode를 설정 할 수 있는 전역 변수를 선언하고 hookManger함수에서 사용할 수 있도록 한다.
+
+- 반환: VNode의 HookMetaData필드를 쉽게 관리 할 수 있는 함수를 반환한다.
+
+  - meta 훅 등록 helper 함수\_registerHookHelper
+  - 훅 상태 조회 훅
+  - isEmpty 불리언 판단 함수
+
+### 반환 함수 설계
+
+-> 반환되는 함수들은 hook들에서 사용 될 수 있다.
+
+- 먼저 반환 함수들이 훅 내부에서 사용되는 상황을 생각해 보자.
+
+#### 흐름...?
+
+- render 함수가 각 노드들을 순환하면서 함수 컴포넌트를 실행시키고 이때 hook함수도 실행이 된다.
+- 이때 훅들이 실행 될때 해당 hooks[hooksPointer] 를 먼저 확인하고 비어있으면(isEmpty 함수로 확인)
+
+#### registerHookHelper
+
+- 입력: set함수에서 등록하려는 상태 값
+- 행동: VNode의 메타 훅 배열의 상태를
+
+- 해당하는 VNode.HookMetaData.hooks에 훅이 없으면
+  currentVNode
+  hookPointer
+
+## 수정사항
+
+### currentVNode관리 방식 수정
+
+- 기존에
+
+```javascript
+let currentVNode: VNode;
+export function getCurrentVNode(VNode: VNode) {
+  currentVNode = VNode;
+}
+```
+
+이런 식으로 단순하게 변수에 객체의 주소값을 할당하는 식으로 했지만 이렇게 되면 컴포넌트가 중첩되고 컴포넌트안에서 다른 컴포넌트를 호출하는데 호출한 컴포넌트안에 상태 관리 훅이 있으면 기존의 currentVNode를 덮어써서 뒤에서 훅이 실행될 때 원래의 VNode가 아닌 마지막으로 set된 VNode를 참조할 위험이 있음.
+
+```javascript
+function A() {
+  const vnodeA = currentVNode; // A의 VNode
+  B(); // 내부에서 또 getCurrentVNode 호출
+  // …이후 A 훅이 실행될 때 currentVNode는 B의 VNode가 된다…
+}
+function B() {
+  /* getCurrentVNode(vnodeB) */
+}
+```
+
+---
+
+- 스택 구조로 전환
+  -> 정확한 VNode 참조를 위해 render 작업이 시작될 시점에 push로 해당 VNode를 넣어주고, 모든 작업이 끝나면 마지막에 pop으로 해당 VNode를 제거한다.
+
+```javascript
+let vnodeStack: VNode[] = [];
+
+export function pushCurrentVNode(vnode: VNode) {
+  vnodeStack.push(vnode);
+}
+export function popCurrentVNode() {
+  vnodeStack.pop();
+}
+
+export function getCurrentVNode(): VNode {
+  return vnodeStack[vnodeStack.length - 1];
+}
+```

--- a/src/core/hook/hookManager/index.ts
+++ b/src/core/hook/hookManager/index.ts
@@ -1,4 +1,8 @@
-import type { HookMetaData, VNode } from "@/shared/types/vnode";
+import type {
+  HookMetaData,
+  HookMetaDataArr,
+  VNode,
+} from "@/shared/types/vnode";
 
 let vnodeStack: VNode[] = [];
 
@@ -31,8 +35,7 @@ export function useHookManger(): [
   isInit: () => boolean
 ] {
   const hookMetaData = getCurrentVNode().hookMetaData!;
-  const hooks: Array<[unknown, (newValue: any) => void, number]> =
-    hookMetaData.hooks as Array<[unknown, (newValue: any) => void, number]>;
+  const hooks: HookMetaDataArr = hookMetaData.hooks as HookMetaDataArr;
 
   /**
    *
@@ -46,13 +49,17 @@ export function useHookManger(): [
     setterFn: (newState: any) => void
   ): void => {
     // TODO: 그냥 push로 하면 안되는거야? 고민 해보기
-    hooks[hookMetaData.pointer] = [state, setterFn, hookMetaData.pointer];
-    hookMetaData.pointer++;
+    hooks.push([state, setterFn]);
     /**
-     * hooks.push([state, setterFn, hookMetaData.pointer])
+     *  hooks[hookMetaData.pointer] = [state, setterFn];
+     * hookMetaData.pointer++;
      */
   };
 
+  /**
+   *
+   * @returns VNode의 pointer 필드를 이용해 올바른 순서의 hookData배열을 반환합니다.
+   */
   const getCurrentHookData = (): HookMetaData => {
     const currentHookData = hooks[hookMetaData.pointer];
     hookMetaData.pointer++;

--- a/src/core/hook/hookManager/index.ts
+++ b/src/core/hook/hookManager/index.ts
@@ -1,0 +1,36 @@
+import type { VNode } from "@/shared/types/vnode";
+
+let vnodeStack: VNode[] = [];
+
+export function pushCurrentVNode(vnode: VNode) {
+  vnodeStack.push(vnode);
+}
+export function popCurrentVNode() {
+  vnodeStack.pop();
+}
+
+/**
+ *
+ * @returns 현재의 VNode의 참조값을 가져옵니다.
+ *
+ * hook함수 내부에서 현재의 VNode에 접근할 수 있습니다.
+ */
+export function getCurrentVNode(): VNode {
+  return vnodeStack[vnodeStack.length - 1];
+}
+
+export function hookManger() {
+  const metaData = getCurrentVNode().hookMetaData!;
+  const hooks: (string | number | boolean)[] = metaData.hooks;
+
+  const registerStateHelper = (state: any): void => {
+    hooks[metaData.pointer] = state;
+    metaData.pointer++;
+  };
+
+  const getState = () => hooks[metaData.pointer];
+
+  const isInit = (): boolean => !!hooks[metaData.pointer];
+
+  return [registerStateHelper, getState, isInit];
+}

--- a/src/core/hook/hookManager/index.ts
+++ b/src/core/hook/hookManager/index.ts
@@ -1,4 +1,4 @@
-import type { VNode } from "@/shared/types/vnode";
+import type { HookMetaData, VNode } from "@/shared/types/vnode";
 
 let vnodeStack: VNode[] = [];
 
@@ -18,19 +18,60 @@ export function popCurrentVNode() {
 export function getCurrentVNode(): VNode {
   return vnodeStack[vnodeStack.length - 1];
 }
+/**
+ *
+ * @returns [registerHookHelper, getVNode, isInit] 를 반환합니다.
+ *
+ * 위 3개의 헬퍼함수를 반환합니다.
+ */
+export function useHookManger(): [
+  registerHookHelper: (state: any, setterFn: (newState: any) => void) => void,
+  getVNode: () => VNode,
+  getCurrentHookData: () => HookMetaData,
+  isInit: () => boolean
+] {
+  const hookMetaData = getCurrentVNode().hookMetaData!;
+  const hooks: Array<[unknown, (newValue: any) => void, number]> =
+    hookMetaData.hooks as Array<[unknown, (newValue: any) => void, number]>;
 
-export function hookManger() {
-  const metaData = getCurrentVNode().hookMetaData!;
-  const hooks: (string | number | boolean)[] = metaData.hooks;
-
-  const registerStateHelper = (state: any): void => {
-    hooks[metaData.pointer] = state;
-    metaData.pointer++;
+  /**
+   *
+   * @param state hook의 상태
+   * @param setterFn 등록할 setter 함수
+   *
+   * hook의 상태,setter함수(클로저 이용),해당hook의 pointer를 등록 합니다.
+   */
+  const registerHookHelper = (
+    state: any,
+    setterFn: (newState: any) => void
+  ): void => {
+    // TODO: 그냥 push로 하면 안되는거야? 고민 해보기
+    hooks[hookMetaData.pointer] = [state, setterFn, hookMetaData.pointer];
+    hookMetaData.pointer++;
+    /**
+     * hooks.push([state, setterFn, hookMetaData.pointer])
+     */
   };
 
-  const getState = () => hooks[metaData.pointer];
+  const getCurrentHookData = (): HookMetaData => {
+    const currentHookData = hooks[hookMetaData.pointer];
+    hookMetaData.pointer++;
+    return currentHookData;
+  };
 
-  const isInit = (): boolean => !!hooks[metaData.pointer];
+  /**
+   *
+   * @returns 현재의 VNode를 가져올 수 있습니다.
+   */
+  const getVNode = () => getCurrentVNode();
 
-  return [registerStateHelper, getState, isInit];
+  /**
+   *
+   * @returns 마운트, 리렌더링 분기를 불리언 타입으로 반환 합니다.
+   *
+   * 초기 마운트 상황일 때는 true를 , 리렌더링 상황이면 hookMetaData.pointer필드에 값이 있으므로 false를 반환합니다.
+   */
+  const isInit = (): boolean => !hooks[hookMetaData.pointer];
+
+  return [registerHookHelper, getVNode, getCurrentHookData, isInit];
 }

--- a/src/core/hook/useState/README.md
+++ b/src/core/hook/useState/README.md
@@ -1,0 +1,53 @@
+# useState설계
+
+- 내가 설계한 전체 흐름은 다음과 같다.
+  - 최초 렌더링시에(render 함수 실행시) VDOM을 돌면서 useState를 실행 시키는 순간에 useState에 의해 반환되는 각각의 setter 함수가 그 순간에는 현재의 해당하는 VNode를 알고 있으니까 내가 setter 함수에 클로저로 hookMetaData필드가 추가된 Vnode를 연결.
+  - 그러면 나중에 setter 함수가 실행될 때 해당 setter 함수 안에는 클로저로 어떤 VNode에서 실행이 되는지 알 수 있음.
+    그래서 setter 가 발생한 노드부터 리렌더링을 시작해서 rootVNode와 비교를 하면서 부분 수정을 한다.
+
+## useState란?
+
+- `useState`는 React 함수형 컴포넌트 내에서 상태 변수를 선언하고 업데이트할 수 있도록 돕는 훅.
+- 여기서 ‘상태’는 시간이 지남에 따라 변할 수 있는 동적인 값(예: 버튼 클릭 횟수, 입력된 텍스트 등)을 의미.
+- `useState`는 이러한 **_상태 값이 변경될 때_**마다 컴포넌트를 자동으로 리렌더링하여 화면에 변경된 값을 반영
+
+## 주요 기능
+
+```javascript
+//jsx
+import { useState } from "myReact";
+
+function MyComponent() {
+  const [state, setState] = useState(initialValue);
+  // ... 컴포넌트 로직
+}
+```
+
+- `state`: 현재 상태 값.
+- `setState`: 상태 값을 업데이트 하는 함수. 이 함수를 호출 하면 컴포넌트가 새로운 값을 리렌더링 된다.
+- 다중 상태 변수 지원: 하나의 컴포넌트 내에서 여러 개의 `useState`를 사용하여 다양한 상태 변수를 가질 수 있다.
+
+## 설계
+
+- 우선 실행 시점으로 크게 분리해서 생각한다.
+  1. 최초 마운트 시점
+  2. 리렌더링 시점
+- 하지만 실행 시점을 판단 하려면 처음에 useState가 클로저로 VNode를 갖고있는지 확인한다.
+  - 클로저에 VNode가 존재하지 않으면 useHookManger를 이용해서 VNode의 접근 헬퍼 함수를 얻어서 useState의 클로저로 VNdoe를 등록한다.
+  - setter 함수로인해 리렌더링이 되는경우에는 useState의 클로저에 VNode가 존재하면 리렌더링 관련 로직을 실행한다.
+
+### 분기 처리 이후 로직
+
+- 우선 앞의 두가지 실행 시점으로 분기 처리가 되지만 어떤 상황이던 useState라는 함수는 항상 실행되고 이때마다 state와 setState는 반환이 되야한다.
+- setter 함수는 클로저로 해당 하는 VNode의 참조가 있어야 한다. -> 훅 매니저의 반환 함수인 getVNode를 호출 후 변수에 담아서 클로저로 갖고 있도록 한다.
+  - 이렇게 클로저로 갖고있으면 setter 함수가 어떤 노드에 실행되고 해당하는 위치의 setter 함수는 클로저로 getHookMetaData를 갖고있어서 state, setterFn, hookMetaData.pointer 이 정보를 알 수 있다.
+
+### 1. 최초 마운트 순간.
+
+- 이때 render함수가 호출되면서 useState함수도 호출된다.
+- 해당 함수 내부에서 해당하는 VNode의 hookMetaData필드의 hooks이 비어있는지 확인한다. -> 이때 훅 매니저의 isInit으로 판단.
+- 훅 매니저의 registerHookHelper 함수 이용. -> 해당 함수의 매개변수를 입력하기만 하면 해당 VNode에 등록이 된다.
+
+### 2. 리렌더링 시점
+
+- 이때는 setter 함수가 호출이 되는 순간 -> setter

--- a/src/core/hook/useState/index.ts
+++ b/src/core/hook/useState/index.ts
@@ -1,0 +1,35 @@
+import type { HookMetaData, SetState, State } from "@/shared/types/vnode";
+import { useHookManger } from "../hookManager";
+
+export function useState(initalValue: State) {
+  //useHookManger가 호출 되면서 내부의 헬퍼 함수들은 각각 현재의 VNode를 렉시컬 환경에 갖고 있다.
+  const [registerHookHelper, getVNode, getCurrentHookData, isInit] =
+    useHookManger();
+  let state: State;
+
+  /**
+   *
+   * @param arg 함수 또는 일단 상태 초기값을 받는다
+   */
+  let setState: SetState;
+  if (isInit()) {
+    //초깃값 할당
+    state = initalValue;
+    setState = (arg: any) => {
+      if (typeof arg === "function") {
+        state = arg(state);
+      } else {
+        state = arg;
+      }
+      registerHookHelper(state, setState);
+      //리렌더링 호출
+    };
+    //만들어진 hook데이터 배열을 rootVNode에 최초 등록 한다.
+    registerHookHelper(state, setState);
+  } else {
+    const [currentState, currentSetState]: HookMetaData = getCurrentHookData();
+    state = currentState;
+    setState = currentSetState;
+  }
+  return [state, setState];
+}

--- a/src/core/render/internalRender.ts
+++ b/src/core/render/internalRender.ts
@@ -10,6 +10,7 @@ export function internalRender(vnode: VNode, parent: Node): void {
     if (!vnode.hookMetaData) {
       vnode.hookMetaData = { hooks: [], pointer: 0 };
     } else {
+      //함수형 컴포넌트 실행전 pointer 초기화 작업
       vnode.hookMetaData.pointer = 0;
     }
     internalRender(vnode.type(vnode.props), parent);

--- a/src/core/render/internalRender.ts
+++ b/src/core/render/internalRender.ts
@@ -7,7 +7,11 @@ export function internalRender(vnode: VNode, parent: Node): void {
   if (typeof vnode.type === "function") {
     pushCurrentVNode(vnode);
     //VNode에 새로운 필드 추가(render 함수 실행 과정에 한정한다.) rerender과정에서는 이런 과정이 포함되어선 안된다.
-    vnode.hookMetaData = { hooks: [], pointer: 0 };
+    if (!vnode.hookMetaData) {
+      vnode.hookMetaData = { hooks: [], pointer: 0 };
+    } else {
+      vnode.hookMetaData.pointer = 0;
+    }
     internalRender(vnode.type(vnode.props), parent);
     popCurrentVNode();
     return;

--- a/src/core/render/internalRender.ts
+++ b/src/core/render/internalRender.ts
@@ -1,10 +1,15 @@
 import type { VNode } from "@/shared/types/vnode";
 import { mapPropToAttr } from "./mapPropToAttr";
 import { attachHandlers } from "./attachHandlers";
+import { pushCurrentVNode, popCurrentVNode } from "../hook/hookManager";
 
 export function internalRender(vnode: VNode, parent: Node): void {
   if (typeof vnode.type === "function") {
+    pushCurrentVNode(vnode);
+    //VNode에 새로운 필드 추가(render 함수 실행 과정에 한정한다.) rerender과정에서는 이런 과정이 포함되어선 안된다.
+    vnode.hookMetaData = { hooks: [], pointer: 0 };
     internalRender(vnode.type(vnode.props), parent);
+    popCurrentVNode();
     return;
   }
 

--- a/src/core/render/render.ts
+++ b/src/core/render/render.ts
@@ -1,6 +1,7 @@
 import type { VNode } from "@/shared/types/vnode";
 import { internalRender } from "./internalRender";
 import { eventList } from "./eventHandelr";
+import { setRootVDOM } from "../rootNode";
 
 // 요소에 저장된 이벤트 핸들러들의 타입 정의
 interface ElementEventHandlers {
@@ -14,6 +15,7 @@ const delegatedContainers = new WeakSet<Node>();
 export const HANDLERS = Symbol("__handlers"); //Symbol.for
 
 export function render(vnode: VNode, container: Node | HTMLElement): void {
+  setRootVDOM(vnode);
   // 2) 빌드 단계: DocumentFragment 생성
   const fragment: DocumentFragment = document.createDocumentFragment();
 

--- a/src/core/render/render.ts
+++ b/src/core/render/render.ts
@@ -40,6 +40,7 @@ export function render(vnode: VNode, container: Node | HTMLElement): void {
   //---------------------------------------------------------
 
   // 4) 커밋 단계: fragment를 실제 container에 한 번에 붙임
+  //-----------------------> !!!!!!!!!!!!!!!!!!!!!!!!!!!! 이 로직 분리하기!!!!!!!!!!!!!!!!!!!!!!!!! -> 따로 분리해야한다. -> 왜 ???? 리렌더링 할때 아래 로직 즉, 실제 DOM에 바로 업데이트하는 로직이 같이 있으면 안된다.
   container.appendChild(fragment);
 }
 

--- a/src/core/rootNode/index.ts
+++ b/src/core/rootNode/index.ts
@@ -1,0 +1,16 @@
+import type { VNode } from "@/shared/types/vnode";
+
+/**
+ * Render과정 이후 최초에 render가 실행될때 생성되는 기준 VDOM입니다.
+ * 이후에 재조정 과정의 diif 비교일때 기준대상은 항상 rootVDOM이 됩니다.
+ * 변경사항이 발생하면 rootVDOM이 수정되고, 변경된 rootVDOM을 기준으로 DOM이 생성됩니다.
+ */
+let rootVDOM: VNode | null = null;
+
+export function setRootVDOM(vnode: VNode): void {
+  rootVDOM = vnode;
+}
+
+export function getRootVDOM(): VNode {
+  return rootVDOM!;
+}

--- a/src/core/rootNode/index.ts
+++ b/src/core/rootNode/index.ts
@@ -7,10 +7,18 @@ import type { VNode } from "@/shared/types/vnode";
  */
 let rootVDOM: VNode | null = null;
 
+/**
+ *
+ * @param vnode render함수가 실행될때 초반에 최상위의 Vnode의 참조값을 입력 받아야합니다.
+ */
 export function setRootVDOM(vnode: VNode): void {
   rootVDOM = vnode;
 }
 
+/**
+ *
+ * @returns 변경점이 발생하면 항상 rootVDOM에 접근해야하는데 해당 함수를 통해 접근 할 수 있습니다.
+ */
 export function getRootVDOM(): VNode {
   return rootVDOM!;
 }

--- a/src/shared/types/vnode.ts
+++ b/src/shared/types/vnode.ts
@@ -1,13 +1,20 @@
 import type { HTMLAttributes } from "./props";
+
 export type Child = VNode | string | number | null;
 export type Children = Child[] | null;
+type State = unknown;
+type SetState = (newValue: any) => void;
+type Pointer = number;
+export type HookMetaData = [State, SetState, Pointer];
+export type HookMetaDataArr = Array<HookMetaData>;
 export interface VNode {
   type: string | Function;
   key: string | number | null;
   ref: any;
   props: HTMLAttributes & { children: Children };
   hookMetaData?: {
-    hooks: (string | number | boolean)[];
+    //TODO:포인터를 굳이 넣을 필요가 있을까...?
+    hooks: HookMetaDataArr;
     pointer: number;
   };
 }

--- a/src/shared/types/vnode.ts
+++ b/src/shared/types/vnode.ts
@@ -6,4 +6,8 @@ export interface VNode {
   key: string | number | null;
   ref: any;
   props: HTMLAttributes & { children: Children };
+  hookMetaData?: {
+    hooks: (string | number | boolean)[];
+    pointer: number;
+  };
 }

--- a/src/shared/types/vnode.ts
+++ b/src/shared/types/vnode.ts
@@ -2,10 +2,9 @@ import type { HTMLAttributes } from "./props";
 
 export type Child = VNode | string | number | null;
 export type Children = Child[] | null;
-type State = unknown;
-type SetState = (newValue: any) => void;
-type Pointer = number;
-export type HookMetaData = [State, SetState, Pointer];
+export type State = unknown;
+export type SetState = (newValue: any) => void;
+export type HookMetaData = [State, SetState];
 export type HookMetaDataArr = Array<HookMetaData>;
 export interface VNode {
   type: string | Function;
@@ -13,7 +12,6 @@ export interface VNode {
   ref: any;
   props: HTMLAttributes & { children: Children };
   hookMetaData?: {
-    //TODO:포인터를 굳이 넣을 필요가 있을까...?
     hooks: HookMetaDataArr;
     pointer: number;
   };


### PR DESCRIPTION
## 📌 개요  
이번 PR에서는 **함수형 컴포넌트용 `useState` 훅**을 직접 구현하고, 이를 위해 필요한 **VDOM(가상 DOM) 순환·훅 매니저(`HookManager`) 구조**를 설계·구현한 전체 흐름을 자세히 정리합니다.  

- **목표**  
  1. 컴포넌트 내에서 `useState`를 호출하면 각 VNode에 상태(`state`)와 상태 업데이트 함수(`setState`)를 연결  
  2. `setState` 호출 시 해당 VNode를 기준으로 “부분 리렌더링”을 시작하여 변경된 부분만 실제 DOM에 반영  
  3. 훅들이 여러 개 섞여 있어도 올바른 순서로 상태를 보관·조회  

---

## 🔍 시스템 전체 흐름 정리  

1. **최초 마운트 시**  
   - `render(vnode, container)` 호출  
   - `internalRender(vnode, fragment)`가 VNode 트리를 DFS 순회  
   - VNode 타입이 함수형 컴포넌트인 경우  
     1. `pushCurrentVNode(vnode)`로 스택에 현재 VNode 푸시  
     2. `hookMetaData = { hooks: [], pointer: 0 }` 필드 생성  
     3. `vnode.type(vnode.props)`를 재귀 호출하여 자식 VNode 생성  
     4. `popCurrentVNode()`로 스택에서 팝  
   - 비함수형(HTML) VNode인 경우 `document.createElement`, props·children 처리 후 부모에 `appendChild`  

2. **`useState` 훅 동작**  
   - `useState(initialValue)` 내부에서  
     1. `[registerHookHelper, getVNode, getCurrentHookData, isInit] = useHookManger()` 호출  
     2. **마운트 시점**(`isInit() === true`)  
        - `state = initialValue` 설정  
        - `setState = (arg) ⇒ { …; registerHookHelper(state, setState); /* 리렌더링 호출 */ }`  
        - 최초 `registerHookHelper(state, setState)`로 `hooks` 배열에 푸시  
     3. **리렌더링 시점**(`isInit() === false`)  
        - `[currentState, currentSetState] = getCurrentHookData()`로 이전 상태·함수 조회  
        - `state = currentState`, `setState = currentSetState`  

3. **훅 매니저(`HookManager`) 구조**  
   - 전역 `vnodeStack: VNode[]`로 현재 렌더링 중인 VNode 관리  
     ```ts
     export function pushCurrentVNode(vnode: VNode) { vnodeStack.push(vnode); }
     export function popCurrentVNode() { vnodeStack.pop(); }
     export function getCurrentVNode(): VNode { return vnodeStack[vnodeStack.length - 1]; }
     ```
   - `useHookManger()` 반환 값  
     ```ts
     function useHookManger(): [
       registerHookHelper: (state: any, setterFn: (newState: any) => void) => void,
       getVNode: () => VNode,
       getCurrentHookData: () => HookMetaData,
       isInit: () => boolean
     ] { … }
     ```
   - 주요 헬퍼  
     - `registerHookHelper(state, setterFn)`: 현재 VNode의 `hooks` 배열에 `[state, setterFn]` 등록  
     - `getCurrentHookData()`: `hooks[pointer++]`를 반환  
     - `isInit()`: 아직 등록된 데이터가 없으면 `true`  

---

## ⚠️ 발견된 결함 및 원인 분석  

### 1. VNode 싱크 문제  
- **문제**: `setState` 호출 시 “부분 리렌더링”을 위해 해당 VNode를 root로 삼아 새로운 VDOM을 생성하면,  
  - 최상위 VNode는 기존 참조를 유지하지만  
  - **하위 VNode들은 모두 새로 생성된 객체**이므로 이전에 저장된 `hookMetaData`를 참조할 수 없음.  
- **결과**: 리렌더링된 자식 컴포넌트들은 매번 `initialValue` 상태로 돌아가 버림.

### 2. 근본 원인  
- **함수 컴포넌트 실행 시마다 새로운 VNode 반환**  
- **기존 VNode와 매칭 없이** 새 VNode에 `hookMetaData`를 주입하지 않음  
- **자료구조·트리 탐색 지식 부족**으로, VDOM 트리 간 1:1 매핑 로직 미구현  

---

## 🛠️ 보완 계획  

1. **VDOM Diff & Reconciliation 도입**  
   - 기존 VDOM(`origin`)과 새 VDOM(`new`)을 **동기적으로 DFS 순회**하며 1:1 노드 매칭  
   - 매칭된 노드에만 `hookMetaData` 주입  
   - 매칭 실패 시(타입 변경, key 변경 등) 신규 마운트 처리  

2. **실시간 비교 통합**  
   - `internalRender` 단계에서 각 VNode 방문 시  
     1. `origin` 트리의 같은 위치 VNode를 찾고  
     2. `newVNode.hookMetaData = originVNode.hookMetaData` 적용  
     3. 이후 마운트 또는 업데이트 로직 실행  

3. **Reconciliation API 설계**  
   - `diff(originVNode: VNode, newVNode: VNode): void`  
   - `patch(domNode: Node, originVNode: VNode, newVNode: VNode): void`  
   - `key` 속성 지원을 통한 효율적 리스트 재배치  

4. **추가 학습 & 리팩토링**  
   - 자료구조·트리 구조·트리 순환(DFS, BFS, 탐색 알고리즘) 개념 복습  
   - 디자인 패턴(Visitor, Iterator 등) 적용 검토  
   - VDOM 최적화 전략(직접 Compare vs. Fiber 구조) 연구  

---

## ✔️ 구현 내용 요약  

- **`internalRender.ts`**  
  - VNode 재귀 순환 구조 구현  
  - 함수형 컴포넌트 진입 시 `hookMetaData` 초기화·재사용 로직 추가  
- **`render.ts`**  
  - `setRootVDOM`으로 최초 VDOM 저장  
  - DocumentFragment + 이벤트 위임 분리  
- **`hookManager/index.ts`**  
  - `vnodeStack` 스택 기반 VNode 관리  
  - `useHookManger()`로 훅 헬퍼 함수 집합 반환  
- **`useState/index.ts`**  
  - 마운트·리렌더링 판단(`isInit`) 후 `hooks` 배열에서 상태 관리  
  - `setState` 클로저로 VNode·hookMetaData 연계  

---

## 기존 설계에 대한 복기
- 이런 문제가 발생한 근본적 원인을 생각해 봤는데 결국은 지식이 부족해서 이런 일이 발생했다고 생각합니다.
그래서 먼저 자료구조, 트리구조, 트리순환, DFS, 탐색 알고리즘.. 이런 개념들을 먼저 공부하고 다시 해당 문제에 대해 다시 설계를 하고 보완할 계획입니다.

- 지금까지 구현 한 내용은 Crong 말대로 최대한 리액트의 원리를 참고하지 않고, 최대한 제 생각대로 설계한 결과입니다. 하지만 구현한 로직들의 명칭 지정 이슈..? 로 리액트의 용어를 참고했습니다. 앞으로 최대한 리액트의 내부 시스템 흐름을 참고하지 않고 지금처럼 제 생각대로 설계해 보겠습니다....

## 🔚 결론 및 다음 단계  

이번 PR은 **함수형 훅 시스템의 기초 골격**을 마련하는 작업으로,  
`useState` 훅이 VNode별로 상태를 유지하고 업데이트하는 기본 메커니즘을 구현했습니다.  
다만 “VDOM 싱크” 문제로, 부분 리렌더링 시 상태 유지에 결함이 남아 있어,  
다음 단계에서는 **Reconciliation(재조정) 알고리즘**을 도입하여 VNode 간 정확한 매핑과 기존 상태 주입을 완성할 예정입니다.  

추가 학습 및 구조 설계를 바탕으로 안정적인 훅 기반 렌더링 엔진을 완성해 나가겠습니다.  
감사합니다.  

