### PR TITLE
[wanja] 기존 설계 문제점 파악 및 재설계 방향 수립

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ src/
 - [x] 개발 환경 구성 (Vite, Babel, ESLint, Prettier, Vitest)
 - [x] JSX → createElement 트랜스파일러 연동
 - [x] 컴포넌트 시스템 구현
-- [ ] 이벤트 위임 방식 도입
+- [x] 이벤트 위임 방식 도입
 - [ ] 상태 관리 및 리렌더링 시스템 구축
 - [ ] (선택) 가상 DOM 및 diff 알고리즘
 - [ ] (선택) SPA 라우터

--- a/src/__tests__/useState.test.jsx
+++ b/src/__tests__/useState.test.jsx
@@ -1,5 +1,5 @@
 import { useState } from '../core/useState';
-import { render } from '../core/render';
+import { reRender, renderRoot } from '../core/render';
 import { createElement } from '../core/createElement';
 
 describe('useState 훅', () => {
@@ -19,7 +19,7 @@ describe('useState 훅', () => {
 
   function mount(AppComponent) {
     vnode = createElement(AppComponent);
-    render(vnode, root);
+    renderRoot(vnode, root);
   }
 
   it('초기 상태값이 DOM에 정확히 반영되어야 한다', () => {
@@ -78,25 +78,8 @@ describe('useState 훅', () => {
     expect(getCount2().textContent).toBe('110');
   });
 
-  it('상태 변경 후 vnode.__dom이 새로운 DOM 노드를 가리켜야 한다', () => {
-    const App = () => {
-      const [count, setCount] = useState(0);
-      window.bump = () => setCount((c) => c + 1);
-      return <div data-testid="count">num: {count}</div>;
-    };
-
-    mount(App);
-    const initialDom = vnode.__dom;
-    window.bump();
-    const updatedDom = vnode.__dom;
-
-    const countNode = root.querySelector('[data-testid="count"]');
-    expect(updatedDom).toBe(countNode);
-    expect(updatedDom).not.toBe(initialDom);
-    expect(updatedDom.textContent).toBe('num: 1');
-  });
-
-  it('중첩 컴포넌트에서 상태 변경 시 해당 부분만 다시 렌더링되어야 한다', () => {
+  // TODO: 부분리랜더링에 필요한 재조정, diff 설계 이후 다시 테스트
+  it.skip('중첩 컴포넌트에서 상태 변경 시 해당 부분만 다시 렌더링되어야 한다', () => {
     const App = () => {
       const [countA, setCountA] = useState(0);
       const [countB, setCountB] = useState(0);
@@ -162,5 +145,17 @@ describe('useState 훅', () => {
     expect(renderCount).toBe(1);
     window.same();
     expect(renderCount).toBe(1); // 값이 같으므로 리렌더링 없어야 함
+  });
+
+  it('reRender 호출 시 전체 앱이 재렌더링 되어야 한다', () => {
+    const spy = vi.fn();
+    const App = () => {
+      spy();
+      return <div />;
+    };
+    mount(App);
+    expect(spy).toHaveBeenCalledTimes(1);
+    reRender();
+    expect(spy).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -1,17 +1,15 @@
 import Sample from './Sample';
+import { useState } from '../core/useState';
 
-export default function App({ name }) {
+export default function App() {
+  const [count, setCount] = useState(0);
+
   return (
     <div className="container">
-      <h1 className="title">Welcome to My App, {name}</h1>
-      <section className="intro">
-        <p>Hello, this is a simple custom renderer demo.</p>
-        <ul>
-          <li key="1">Supports JSX</li>
-          <li key="2">Handles nested elements</li>
-          <li key="3">Applies basic props like className</li>
-        </ul>
-      </section>
+      <button onClick={() => setCount((prev) => prev + 1)}>
+        부모버튼 : {count}
+      </button>
+
       <Sample />
     </div>
   );

--- a/src/app/Sample.jsx
+++ b/src/app/Sample.jsx
@@ -1,16 +1,11 @@
-export default function Sample() {
-  return (
-    <div>
-      Sample
-      <ChildSample />
-    </div>
-  );
-}
+import { useState } from '../core/useState';
 
-function ChildSample() {
+export default function Sample() {
+  const [count, setCount] = useState(0);
+
   return (
-    <div>
-      ChildSample <div>oh~</div>
-    </div>
+    <button onClick={() => setCount((prev) => prev + 1)}>
+      자식버튼 : {count}
+    </button>
   );
 }

--- a/src/app/main.jsx
+++ b/src/app/main.jsx
@@ -1,6 +1,6 @@
-import { render } from '../core/render';
+import { renderRoot } from '../core/render';
 import App from './App';
 
 const root = document.getElementById('root');
 
-render(<App name="wanja" />, root);
+renderRoot(<App />, root);

--- a/src/core/useState.js
+++ b/src/core/useState.js
@@ -10,6 +10,7 @@ export function useState(initialValue) {
     stateBucket[hookIndex] = initialValue;
   }
 
+  // #1 이 훅이 사용할 “슬롯 번호”를 고정(snapshot)
   const currentIndex = hookIndex;
 
   function setState(nextValue) {
@@ -20,10 +21,12 @@ export function useState(initialValue) {
       return; // 값이 동일하면 리렌더링 방지
     }
     stateBucket[currentIndex] = next;
-    reRender(); // 전체 리랜더링 로직
+    reRender();
   }
 
+  // #2. 다음 훅 호출을 위해 인덱스 증가
   state.hookIndex++;
 
+  // #1 을 참조하여 반환
   return [stateBucket[currentIndex], setState];
 }

--- a/src/core/useState.js
+++ b/src/core/useState.js
@@ -1,4 +1,5 @@
 import { getCurrentState } from './context';
+import { reRender } from './render';
 
 export function useState(initialValue) {
   //현재 설정된 컴포넌트의 상태 가져오기
@@ -14,14 +15,15 @@ export function useState(initialValue) {
   function setState(nextValue) {
     const prev = stateBucket[currentIndex];
     const next = typeof nextValue === 'function' ? nextValue(prev) : nextValue;
+
     if (Object.is(prev, next)) {
       return; // 값이 동일하면 리렌더링 방지
     }
     stateBucket[currentIndex] = next;
-    state.rerender();
+    reRender(); // 전체 리랜더링 로직
   }
 
   state.hookIndex++;
 
-  return [stateBucket[hookIndex], setState];
+  return [stateBucket[currentIndex], setState];
 }


### PR DESCRIPTION
## 주요 작업 목록

기존의 컴포넌트 부분 리랜더링 로직 제거했습니다 (설계의 한계를 느끼고 재설계 예정)
설계 삽질만 내내...했습니다.

🐛 버그 수정  
- `render` 진입점을 `renderRoot`로 분리하여 전체 애플리케이션 렌더링 흐름 통일  
- 컴포넌트별 `rerender` 콜백 제거  
- `useState` setter에서 컴포넌트 단위가 아닌 `update()` 호출로 전체 재렌더링 수행  
- `rootComponent`/`rootContainer` 전역 변수로 렌더 컨텍스트 관리

✨ 샘플 코드 변경
- 부모와 자식 컴포넌트의 상태 변경 흐름을 한눈에 확인할 수 있는 샘플 코드 업데이트

✅ 테스트 수정
- 테스트에서 `reRender`로 함수명 변경 반영 (import, 호출, `vi.fn()` 사용)  
- `reRender` 호출 시 전체 앱 재렌더링 동작 검증을 위한 테스트 추가

💄 스타일 설정  
- 훅 인덱스 관리 로직에 주석을 추가해 `hookIndex` → `currentIndex` 흐름 가독성 개선  


## 주요 문제와 해결

### 1. 부모가 리랜더링 될 경우, 자식의 변경사항이 반영되지 않았던 문제 (❗️이전 pr에서 해결하지 못했던 문제 해결❗️)

- 부모 컴포넌트의 상태 변경 → 리렌더링 시, 자식 컴포넌트도 함께 렌더링되지만
- 이후 자식에서 상태 변경이 발생해도 **화면에 반영되지 않는 현상**이 발생했습니다.
- 원인 분석 결과, 다음과 같은 구조적 문제가 있었습니다:

#### 🤔 문제 원인

- 기존에는 리렌더 콜백에서 `vnode.__dom`을 통해 실제 DOM을 교체했으나, 부모가 리렌더링되면 자식의 `vnode` 객체도 새로 생성되고,
기존 콜백이 참조하던 `vnode`는 더 이상 실제 DOM과 연결되어 있지 않았습니다.

#### 기존 코드
```js
function createRerenderCallback(vnode, state) {
  return () => {
    const nextVNode = vnode.type(vnode.props);
    const nextDom = createDom(nextVNode);
    vnode.__dom.replaceWith(nextDom);
    vnode.__dom = nextDom;
  };
}
```

- 클로저에 캡처된 `vnode`가 부모 랜더링으로 인한 자식의 새로운 vnode 생성으로 `replaceWith` 대상 DOM이 사라지고, 상태 업데이트가 반영되지 않음


#### ✅ 해결

### 1. `vnode.__dom` → `state.dom` 으로 전환

- 자식이 리랜더링 될 때마다 state.dom에 실제 dom을 계속 업데이트 한다
- 컴포넌트 인스턴스를 표현하는 `state`는 생명주기를 따라가므로,
- **항상 최신의 루트 DOM 노드를 보관할 수 있는 안정적인 저장소**로 활용 가능

### 2. `rerender` 콜백 구조 리팩토링

- 더 이상 `vnode`를 클로저에 보관하지 않으며,
- `state.dom`만을 참조하여 항상 정확한 DOM 교체가 가능하게 개선

#### 변경 후 코드
```js
function createRerenderCallback(state) {
  return () => {
    prepareHookContext(state);
    const nextVNode = state.componentType(state.props);
    const nextDom = createDom(nextVNode);
    const oldDom = state.dom;
    oldDom.replaceWith(nextDom);
    state.dom = nextDom;
  };
}
```

#### 👉 하지만 위의 문제 해결은 아래의 문제로 인해 기존 설계와 코드를 엎기로 결정했습니다.

---

### 2. 기존 함수 컴포넌트 상태 맵핑 설계의 한계

기존의 설계는 상태를 전역 weakMap으로 관리하고, 함수 컴포넌트의 참조를 고유한 key로 삼아 함수 컴포넌트와 상태 저장소를 맵핑시키는 방식이었습니다. 하지만 이 방식으로는 함수 컴포넌트를 재사용할 경우 인스턴스별로 독립적인 상태를 가지지 못하고, 하나의 상태 저장소를 공유하는 문제가 발생합니다. 기존 설계를 바꾸지 않고, 이를 해결할 수 있는 여러가지 방법에 대해서 고민해보았고 결국 기존 설계의 한계를 극복하진 못했지만, 고려했던 방식과 느낀점을  아래 글로 정리해보았습니다.

[관련 wiki 글](https://github.com/wan0514/fe-my-react/wiki/%5B%EB%AC%B8%EC%A0%9C%EC%99%80-%ED%95%B4%EA%B2%B0%5D-useState-%EC%83%81%ED%83%9C-%EB%A7%B5%ED%95%91-%EC%84%A4%EA%B3%84-%ED%9A%8C%EA%B3%A0-%EB%B0%8F-%EC%9E%AC%EC%84%A4%EA%B3%84-%EB%B0%A9%ED%96%A5)


---

## 그래서 앞으로 뭘 할 것인가?

아래의 흐름을 재설계하고, 로직을 하나씩 추가해갈 예정입니다.

- vnode tree를 만드는 로직 추가
- 해당 tree에 각 함수 인스턴스별로 상태 저장소를 넣는 방향으로 변경
- old tree와 new tree를 비교하며 재조정 과정 로직 추가
- diff & patch 를 통해 변경된 사항만 반영되게 하기